### PR TITLE
Add copy pom.xml snippet option for extension and fix a few related bugs

### DIFF
--- a/src/main/frontend/src/code-quarkus/__tests__/launcher-quarkus.spec.tsx
+++ b/src/main/frontend/src/code-quarkus/__tests__/launcher-quarkus.spec.tsx
@@ -9,6 +9,7 @@ jest.mock('../backend-api', () => ({
     {
       "id": "io.quarkus:quarkus-arc",
       "shortId": "8mc",
+      "version": "test-version",
       "name": "ArC",
       "keywords": [
         "arc",
@@ -24,6 +25,7 @@ jest.mock('../backend-api', () => ({
     {
       "id": "io.quarkus:quarkus-resteasy",
       "shortId": "ogy",
+      "version": "test-version",
       "name": "RESTEasy JAX-RS",
       "keywords": [
         "resteasy",
@@ -39,6 +41,7 @@ jest.mock('../backend-api', () => ({
     {
       "id": "io.quarkus:quarkus-resteasy-jsonb",
       "shortId": "14pb",
+      "version": "test-version",
       "name": "RESTEasy JSON-B",
       "keywords": [
         "resteasy-jsonb",
@@ -56,6 +59,7 @@ jest.mock('../backend-api', () => ({
     {
       "id": "io.quarkus:quarkus-resteasy-jackson",
       "shortId": "1aen",
+      "version": "test-version",
       "name": "RESTEasy Jackson",
       "keywords": [
         "resteasy-jackson",

--- a/src/main/frontend/src/code-quarkus/extensions-loader.tsx
+++ b/src/main/frontend/src/code-quarkus/extensions-loader.tsx
@@ -6,6 +6,7 @@ import { fetchExtensions } from './backend-api';
 interface Extension {
   id: string;
   shortId: string;
+  version: string,
   name: string;
   keywords: string[];
   description?: string;

--- a/src/main/frontend/src/code-quarkus/pickers/__tests__/__snapshots__/extensions-picker.spec.tsx.snap
+++ b/src/main/frontend/src/code-quarkus/pickers/__tests__/__snapshots__/extensions-picker.spec.tsx.snap
@@ -228,7 +228,7 @@ exports[`<ExtensionsPicker /> renders the ExtensionsPicker correctly 1`] = `
             >
               <span
                 class="extension-name"
-                title="ArC"
+                title="ArC (test-version)"
               >
                 ArC
               </span>
@@ -305,7 +305,7 @@ exports[`<ExtensionsPicker /> renders the ExtensionsPicker correctly 1`] = `
             >
               <span
                 class="extension-name"
-                title="A CDI in name test"
+                title="A CDI in name test (test-version)"
               >
                 A CDI in name test
               </span>
@@ -388,7 +388,7 @@ exports[`<ExtensionsPicker /> renders the ExtensionsPicker correctly 1`] = `
             >
               <span
                 class="extension-name"
-                title="Camel Netty4 test HTTP"
+                title="Camel Netty4 test HTTP (test-version)"
               >
                 Camel Netty4 test HTTP
               </span>
@@ -678,7 +678,7 @@ exports[`<ExtensionsPicker /> select values and save 1`] = `
           >
             <span
               class="extension-name"
-              title="Camel Netty4 test HTTP"
+              title="Camel Netty4 test HTTP (test-version)"
             >
               Camel Netty4 test HTTP
             </span>
@@ -967,7 +967,7 @@ exports[`<ExtensionsPicker /> show results for valid search 1`] = `
           >
             <span
               class="extension-name"
-              title="ArC"
+              title="ArC (test-version)"
             >
               ArC
             </span>
@@ -1035,7 +1035,7 @@ exports[`<ExtensionsPicker /> show results for valid search 1`] = `
           >
             <span
               class="extension-name"
-              title="A CDI in name test"
+              title="A CDI in name test (test-version)"
             >
               A CDI in name test
             </span>

--- a/src/main/frontend/src/code-quarkus/pickers/__tests__/extensions-picker.spec.tsx
+++ b/src/main/frontend/src/code-quarkus/pickers/__tests__/extensions-picker.spec.tsx
@@ -11,6 +11,7 @@ const entries: ExtensionEntry[] = [
   {
     "id": "io.quarkus:quarkus-arc",
     "name": "ArC",
+    "version": "test-version",
     "shortId": "a",
     "status": "stable",
     "keywords": [
@@ -28,6 +29,7 @@ const entries: ExtensionEntry[] = [
   },
   {
     "id": "io.quarkus:quarkus-camel-netty4-http",
+    "version": "test-version",
     "name": "Camel Netty4 test HTTP",
     "status": "preview",
     "shortId": "b",
@@ -43,6 +45,7 @@ const entries: ExtensionEntry[] = [
   {
     "id": "some-id",
     "shortId": "c",
+    "version": "test-version",
     "name": "A CDI in name test",
     "status": "experimental",
     "default": false,

--- a/src/main/frontend/src/code-quarkus/pickers/extensions-picker.tsx
+++ b/src/main/frontend/src/code-quarkus/pickers/extensions-picker.tsx
@@ -15,6 +15,7 @@ export interface ExtensionEntry {
   id: string;
   shortId: string;
   name: string;
+  version: string;
   keywords: string[];
   description?: string;
   shortName?: string;
@@ -70,8 +71,14 @@ function StatusTag(props: { status?: string }) {
 function More(props: ExtensionEntry) {
   const [isMoreOpen, setIsMoreOpen] = useState(false);
   const analytics = useAnalytics();
+  const gav = `${props.id}:${props.version}`;
+  const gavArray = gav.split(':');
   const addMvnExt = `./mvnw quarkus:add-extension -Dextensions="${props.id}"`;
   const addGradleExt = `./gradlew addExtension --extensions="${props.id}"`;
+  const xml = `<dependency>
+            <groupId>${gavArray[0]}</groupId>
+            <artifactId>${gavArray[1]}</artifactId>
+        </dependency>`;
   const closeMore = () => {
     setTimeout(() => setIsMoreOpen(false), 1000);
   }
@@ -88,8 +95,11 @@ function More(props: ExtensionEntry) {
     <DropdownItem key="gradle" variant="icon">
       <CopyToClipboard event={["Extension", 'Copy the command to add it with Gradle', props.id]} content={addGradleExt} tooltipPosition="left" onClick={closeMore} zIndex={201}>Copy the command to add it with Gradle</CopyToClipboard>
     </DropdownItem>,
+    <DropdownItem key="xml" variant="icon">
+      <CopyToClipboard event={["Extension", "Copy the extension pom.xml snippet", props.id]} content={xml} tooltipPosition="left" onClick={closeMore} zIndex={201}>Copy the extension pom.xml snippet</CopyToClipboard>
+    </DropdownItem>,
     <DropdownItem key="id" variant="icon">
-      <CopyToClipboard event={["Extension", "Copy the GAV", props.id]} content={props.id} tooltipPosition="left" onClick={closeMore} zIndex={201}>Copy the extension GAV</CopyToClipboard>
+      <CopyToClipboard event={["Extension", "Copy the GAV", props.id]} content={gav} tooltipPosition="left" onClick={closeMore} zIndex={201}>Copy the extension GAV</CopyToClipboard>
     </DropdownItem>
   ];
 
@@ -144,7 +154,7 @@ function Extension(props: ExtensionProps) {
       <div className="extension-summary">
         <span
           className="extension-name"
-          title={props.name}
+          title={`${props.name} (${props.version})`}
         >{props.name}</span>
         {props.status && props.status.split(',').map((s, i) => <StatusTag key={i} status={s} />)}
         {props.default && <span

--- a/src/main/kotlin/io/quarkus/code/model/CodeQuarkusExtension.kt
+++ b/src/main/kotlin/io/quarkus/code/model/CodeQuarkusExtension.kt
@@ -3,6 +3,7 @@ package io.quarkus.code.model
 data class CodeQuarkusExtension(
         val id: String,
         val shortId: String,
+        val version: String,
         val name: String,
         val description: String?,
         val shortName: String?,

--- a/src/main/kotlin/io/quarkus/code/services/QuarkusExtensionUtils.kt
+++ b/src/main/kotlin/io/quarkus/code/services/QuarkusExtensionUtils.kt
@@ -84,9 +84,12 @@ object QuarkusExtensionUtils {
             return null
         }
         val keywords = ext.keywords ?: emptyList()
+        val id = "${ext.groupId}:${ext.artifactId}"
+        val shortId = createShortId(id)
         return CodeQuarkusExtension(
-                id ="${ext.groupId}:${ext.artifactId}",
-                shortId = createShortId(ext.artifactId),
+                id = id,
+                shortId = shortId,
+                version = ext.version,
                 name = ext.name,
                 description = ext.description,
                 shortName = getExtensionShortName(ext),
@@ -101,8 +104,8 @@ object QuarkusExtensionUtils {
 
     }
 
-    internal fun createShortId(artifactId: String): String {
-        val normalized = artifactId.replace("^(io.quarkus:)?quarkus-".toRegex(), "")
+    internal fun createShortId(id: String): String {
+        val normalized = id.replace("^(io.quarkus:)?quarkus-".toRegex(), "")
         return shorten(normalized)
     }
 

--- a/src/main/kotlin/io/quarkus/code/services/QuarkusProjectCreator.kt
+++ b/src/main/kotlin/io/quarkus/code/services/QuarkusProjectCreator.kt
@@ -44,20 +44,20 @@ open class QuarkusProjectCreator {
                 val sourceType = CreateProject.determineSourceType(extensions)
                 val context = mutableMapOf("path" to (project.path as Any))
                 val buildTool = io.quarkus.generators.BuildTool.valueOf(project.buildTool)
-                val success = CreateProject(zipWriter)
+                val success = CreateProject(zipWriter, QuarkusExtensionCatalog.descriptor)
                         .groupId(project.groupId)
                         .artifactId(project.artifactId)
                         .version(project.version)
                         .sourceType(sourceType)
                         .buildTool(buildTool)
                         .className(project.className)
-                        .extensions(extensions)
                         .doCreateProject(context)
                 if (!success) {
                     throw IOException("Error during Quarkus project creation")
                 }
-                AddExtensions(zipWriter, buildTool)
-                        .addExtensions(extensions)
+                AddExtensions(zipWriter, buildTool, QuarkusExtensionCatalog.descriptor)
+                        .extensions(extensions)
+                        .execute()
                 if (buildTool == BuildTool.MAVEN) {
                     addMvnw(zipWriter)
                 } else if (buildTool == BuildTool.GRADLE) {

--- a/src/test/kotlin/io/quarkus/code/CodeQuarkusResourceTest.kt
+++ b/src/test/kotlin/io/quarkus/code/CodeQuarkusResourceTest.kt
@@ -24,6 +24,7 @@ class CodeQuarkusResourceTest {
         given()
                 .`when`().get("/api/download")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"code-with-quarkus.zip\"")
@@ -37,6 +38,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?g=org.acme&a=&pv=1.0.0&c=org.acme.TotoResource&s=98e")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -47,6 +49,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?g=org.acme.&s=98e")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -57,6 +60,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?a=Art.&s=98e")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -67,6 +71,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?p=invalid&s=98e")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -77,6 +82,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?c=com.1e&s=98e")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -87,6 +93,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?s=inv")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -97,6 +104,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?e=inv")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(400)
     }
 
@@ -107,6 +115,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?a=test-app-with-a-few-arg&v=1.0.0&s=D9x.9Ie")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-app-with-a-few-arg.zip\"")
@@ -128,6 +137,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?g=org.acme&a=test-empty-shortids&v=1.0.1&b=MAVEN&c=org.acme.ExampleResource&s=")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-empty-shortids.zip\"")
@@ -147,6 +157,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?g=org.acme&a=test-empty-ext&v=1.0.1&b=MAVEN&c=org.acme.ExampleResource&e=")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-empty-ext.zip\"")
@@ -165,8 +176,9 @@ class CodeQuarkusResourceTest {
     fun testWithUrlRewrite() {
         given()
                 .`when`()
-                .get("/d?g=com.toto&a=test-app&v=1.0.0&p=/toto/titi&c=org.toto.TotoResource&s=5Lt.L0j.9Ie")
+                .get("/d?g=com.toto&a=test-app&v=1.0.0&p=/toto/titi&c=org.toto.TotoResource&s=cvj.L0j.9Ie") // camel-quarkus-microprofile-metrics, quarkus-amazon-lambda-http, quarkus-elytron-security-oauth2
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-app.zip\"")
@@ -178,7 +190,7 @@ class CodeQuarkusResourceTest {
                         version = "1.0.0",
                         className = "org.toto.TotoResource",
                         path = "/toto/titi",
-                        shortExtensions = "5Lt.L0j.9Ie"
+                        shortExtensions = "cvj.L0j.9Ie"
                 )
         )
         )
@@ -189,8 +201,9 @@ class CodeQuarkusResourceTest {
     fun testWithAllParams() {
         given()
                 .`when`()
-                .get("/api/download?g=com.toto&a=test-app&v=1.0.0&p=/toto/titi&c=org.toto.TotoResource&s=5Lt.L0j.9Ie")
+                .get("/api/download?g=com.toto&a=test-app&v=1.0.0&p=/toto/titi&c=org.toto.TotoResource&s=cvj.L0j.9Ie")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-app.zip\"")
@@ -202,7 +215,7 @@ class CodeQuarkusResourceTest {
                         version = "1.0.0",
                         className = "org.toto.TotoResource",
                         path = "/toto/titi",
-                        shortExtensions = "5Lt.L0j.9Ie"
+                        shortExtensions = "cvj.L0j.9Ie"
                 ))
         )
     }
@@ -214,6 +227,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?g=com.toto&a=test-app&v=1.0.0&p=/toto/titi&c=com.toto.TotoResource&e=io.quarkus:quarkus-resteasy&s=9Ie")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-app.zip\"")
@@ -238,6 +252,7 @@ class CodeQuarkusResourceTest {
         given()
                 .`when`().get("/api/config")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("environment", equalTo("dev"))
@@ -252,6 +267,7 @@ class CodeQuarkusResourceTest {
         given()
                 .`when`().get("/api/extensions")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("$.size()", greaterThan(50))
@@ -264,6 +280,7 @@ class CodeQuarkusResourceTest {
                 .`when`()
                 .get("/api/download?b=GRADLE&a=test-app-with-a-few-arg&v=1.0.0&s=pDS.L0j")
                 .then()
+                .log().ifValidationFails()
                 .statusCode(200)
                 .contentType("application/zip")
                 .header("Content-Disposition", "attachment; filename=\"test-app-with-a-few-arg.zip\"")

--- a/src/test/kotlin/io/quarkus/code/services/QuarkusExtensionUtilsTest.kt
+++ b/src/test/kotlin/io/quarkus/code/services/QuarkusExtensionUtilsTest.kt
@@ -34,6 +34,7 @@ internal class QuarkusExtensionUtilsTest {
         assertThat(extensions[0], `is`(CodeQuarkusExtension(
                 "io.quarkus:quarkus-arc",
                 "zmg",
+                "999-SNAPSHOT",
                 "ArC",
                 "Build time CDI dependency injection",
                 "CDI",
@@ -48,6 +49,7 @@ internal class QuarkusExtensionUtilsTest {
         assertThat(extensions[5], `is`(CodeQuarkusExtension(
                 "io.quarkus:quarkus-netty",
                 "rpC",
+                "999-SNAPSHOT",
                 "Netty",
                 "Netty is a non-blocking I/O client-server framework. Used by Quarkus as foundation layer.",
                 null,
@@ -79,7 +81,7 @@ internal class QuarkusExtensionUtilsTest {
     }
 
 
-    internal fun getTestDescriptor(): QuarkusJsonPlatformDescriptor {
+    private fun getTestDescriptor(): QuarkusJsonPlatformDescriptor {
         val qpd = QuarkusJsonPlatformDescriptorLoaderImpl()
 
         val artifactResolver = object : ArtifactResolver {

--- a/src/test/kotlin/io/quarkus/code/services/QuarkusProjectCreatorTest.kt
+++ b/src/test/kotlin/io/quarkus/code/services/QuarkusProjectCreatorTest.kt
@@ -1,9 +1,7 @@
 package io.quarkus.code.services
 
 import io.quarkus.code.model.QuarkusProject
-import io.quarkus.platform.descriptor.resolver.json.QuarkusJsonPlatformDescriptorResolver
 import io.quarkus.test.junit.QuarkusTest
-import org.eclipse.microprofile.config.spi.ConfigProviderResolver
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.DisplayName


### PR DESCRIPTION
- Add copy pom.xml snippet:
![image](https://user-images.githubusercontent.com/2223984/77433578-d3657e00-6ddf-11ea-8852-56a380e033aa.png)

- Show version in extension name tooltip (Fixes #314 #230)
<img width="372" alt="Capture d’écran 2020-03-24 à 14 55 24" src="https://user-images.githubusercontent.com/2223984/77433485-b7fa7300-6ddf-11ea-9501-52028f719579.png">

- Add version to "Copy GAV"  (Fixes #313)
![image](https://user-images.githubusercontent.com/2223984/77433097-3acefe00-6ddf-11ea-9585-785a9dcac176.png)

This will change shortIds for extensions where groupId is different from `io.quarkus` (i.e camel)