### PR TITLE
#357 - Pass a search query via URL parameter

### DIFF
--- a/src/main/frontend/src/code-quarkus/api/quarkus-project-utils.ts
+++ b/src/main/frontend/src/code-quarkus/api/quarkus-project-utils.ts
@@ -88,8 +88,7 @@ export function resolveInitialProject(extensions: ExtensionEntry[]) {
 }
 
 const defaultCleanHistory = () => {
-  console.log(`remove query from url: ${window.location.search}`);
-  window.history.replaceState({}, document.title, window.location.href.replace(window.location.search, ''));
+  window.history.replaceState({}, document.title);
 };
 
 export function parseProjectInQuery(extensions: ExtensionEntry[],

--- a/src/main/frontend/src/code-quarkus/api/quarkus-project-utils.ts
+++ b/src/main/frontend/src/code-quarkus/api/quarkus-project-utils.ts
@@ -83,12 +83,24 @@ export function newDefaultProject(): QuarkusProject {
   });
 }
 
+const queryName = 'extension-search';
+
+export function resolveInitialFilterQueryParam(): string {
+  return getParams(queryName) || '';
+}
+
+const getParams = (paramName: string): string | null => {
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams.get(paramName);
+}
+
 export function resolveInitialProject(extensions: ExtensionEntry[]) {
   return parseProjectInQuery(extensions) || newDefaultProject();
 }
 
 const defaultCleanHistory = () => {
-  window.history.replaceState({}, document.title);
+  console.log(`remove query from url: ${window.location.search}`);
+  window.history.replaceState({}, document.title, window.location.href.replace(window.location.search, ''));
 };
 
 export function parseProjectInQuery(extensions: ExtensionEntry[],

--- a/src/main/frontend/src/code-quarkus/pickers/extensions-picker.tsx
+++ b/src/main/frontend/src/code-quarkus/pickers/extensions-picker.tsx
@@ -210,6 +210,7 @@ function Extension(props: ExtensionProps) {
 
 export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
   const [filter, setFilter] = useState('');
+  const queryName = 'extension-search';
   const [keyboardActived, setKeyBoardActived] = useState<number>(-1);
   const analytics = useAnalytics();
   const debouncedSearchEvent = useRef<(events: string[][]) => void>(_.debounce(
@@ -232,12 +233,23 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
   const result = processEntries(filter, props.entries);
 
   useEffect(() => {
+    addParamToFilter();
+  }, []);
+
+  useEffect(() => {
     if (filter.length > 0) {
       const topEvents = result.slice(0, 5).map(r => ['Extension', 'Display in search top 5 results', r.id]);
       debouncedSearchEvent([...topEvents, ['UX', 'Search', filter]]);
     }
   }, [filter, result, debouncedSearchEvent]);
 
+  const addParamToFilter = (): void => {
+    const extensionSearch = getParams(queryName);
+
+    if (extensionSearch) {
+      setFilter(extensionSearch);
+    }
+  };
   const add = (index: number, origin: string) => {
     const id = result[index].id;
     entrySet.add(id);
@@ -261,6 +273,10 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
   const search = (f: string) => {
     setKeyBoardActived(-1);
     setFilter(f);
+  };
+  const getParams = (paramName: string): string | null => {
+    const searchParams = new URLSearchParams(window.location.search);
+    return searchParams.get(paramName);
   };
 
   const flip = (index: number, origin: string) => {

--- a/src/main/frontend/src/code-quarkus/pickers/extensions-picker.tsx
+++ b/src/main/frontend/src/code-quarkus/pickers/extensions-picker.tsx
@@ -3,7 +3,7 @@ import { CheckSquareIcon, EllipsisVIcon, MapIcon, OutlinedSquareIcon, SearchIcon
 import classNames from 'classnames';
 import hotkeys from 'hotkeys-js';
 import _ from 'lodash';
-import React, { KeyboardEvent, useEffect, useRef, useState } from 'react';
+import React, { KeyboardEvent, useEffect, useRef, useState, useCallback } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { InputProps, useAnalytics, CopyToClipboard } from '../../core';
 import { QuarkusBlurb } from '../layout/quarkus-blurb';
@@ -33,6 +33,7 @@ interface ExtensionsPickerProps extends InputProps<ExtensionsPickerValue> {
   entries: ExtensionEntry[];
   placeholder: string;
   buildTool: string;
+  filterParam?: string;
 
   filterFunction?(d: ExtensionEntry): boolean;
 }
@@ -210,7 +211,6 @@ function Extension(props: ExtensionProps) {
 
 export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
   const [filter, setFilter] = useState('');
-  const queryName = 'extension-search';
   const [keyboardActived, setKeyBoardActived] = useState<number>(-1);
   const analytics = useAnalytics();
   const debouncedSearchEvent = useRef<(events: string[][]) => void>(_.debounce(
@@ -232,9 +232,17 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
   };
   const result = processEntries(filter, props.entries);
 
+  const addParamToFilter = useCallback(() => {
+    const extensionSearch = props.filterParam;
+
+    if (extensionSearch) {
+      setFilter(extensionSearch);
+    }
+  }, [props.filterParam]);
+
   useEffect(() => {
     addParamToFilter();
-  }, []);
+  }, [addParamToFilter]);
 
   useEffect(() => {
     if (filter.length > 0) {
@@ -243,13 +251,6 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
     }
   }, [filter, result, debouncedSearchEvent]);
 
-  const addParamToFilter = (): void => {
-    const extensionSearch = getParams(queryName);
-
-    if (extensionSearch) {
-      setFilter(extensionSearch);
-    }
-  };
   const add = (index: number, origin: string) => {
     const id = result[index].id;
     entrySet.add(id);
@@ -273,10 +274,6 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
   const search = (f: string) => {
     setKeyBoardActived(-1);
     setFilter(f);
-  };
-  const getParams = (paramName: string): string | null => {
-    const searchParams = new URLSearchParams(window.location.search);
-    return searchParams.get(paramName);
   };
 
   const flip = (index: number, origin: string) => {

--- a/src/main/frontend/src/code-quarkus/quarkus-project/quarkus-project-edition-form.tsx
+++ b/src/main/frontend/src/code-quarkus/quarkus-project/quarkus-project-edition-form.tsx
@@ -12,6 +12,7 @@ interface CodeQuarkusFormProps {
   setProject: React.Dispatch<SetStateAction<QuarkusProject>>;
   config: Config;
   onSave: (target?: Target) => void;
+  filterParam?: string;
 }
 
 
@@ -55,6 +56,7 @@ export function CodeQuarkusForm(props: CodeQuarkusFormProps) {
           onChange={setExtensions}
           placeholder="RESTEasy, Hibernate ORM, Web..."
           buildTool={props.project.metadata.buildTool}
+          filterParam={props.filterParam}
         />
       </div>
 

--- a/src/main/frontend/src/code-quarkus/quarkus-project/quarkus-project-flow.tsx
+++ b/src/main/frontend/src/code-quarkus/quarkus-project/quarkus-project-flow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { generateProject, newDefaultProject, resolveInitialProject, Target } from '../api/quarkus-project-utils';
+import { generateProject, newDefaultProject, resolveInitialProject, resolveInitialFilterQueryParam, Target } from '../api/quarkus-project-utils';
 import { useAnalytics } from '../../core/analytics';
 import { CodeQuarkusForm } from './quarkus-project-edition-form';
 import { LoadingModal } from '../modals/loading-modal';
@@ -24,6 +24,7 @@ interface QuarkusProjectFlowProps extends CodeQuarkusProps {
 }
 
 export function QuarkusProjectFlow(props: QuarkusProjectFlowProps) {
+  const [filterQuery] = useState<string>(resolveInitialFilterQueryParam());
   const [project, setProject] = useState<QuarkusProject>(resolveInitialProject(props.extensions));
   const [run, setRun] = useState<RunState>({ status: Status.EDITION });
   const analytics = useAnalytics();
@@ -60,7 +61,7 @@ export function QuarkusProjectFlow(props: QuarkusProjectFlowProps) {
 
   return (
     <React.Fragment>
-      <CodeQuarkusForm project={project} setProject={setProject} config={props.config} onSave={generate} extensions={props.extensions}/>
+      <CodeQuarkusForm project={project} setProject={setProject} config={props.config} onSave={generate} extensions={props.extensions} filterParam={filterQuery}/>
       {!run.error && run.status === Status.RUNNING && (
         <LoadingModal/>
       )}


### PR DESCRIPTION
Issue: #357 

Typing something like 'https://code.quarkus.io/?extension-search=camel' in an address line of a browser it's now bring a filtered list of extensions. That's what I've done.

The another variant process 'https://code.quarkus.io/?select=quarkus-resteasy-jackson,camel-quarkus-timer,camel-quarkus-http' it not going to work, in order to make this variant you can use the share button. As like the issue said in the comments.
