### PR TITLE
Update REST API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-jsonb</artifactId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/kotlin/io/quarkus/code/model/CodeQuarkusExtension.kt
+++ b/src/main/kotlin/io/quarkus/code/model/CodeQuarkusExtension.kt
@@ -2,7 +2,10 @@ package io.quarkus.code.model
 
 data class CodeQuarkusExtension(
         val id: String,
+
+        @Deprecated(message = "see https://github.com/quarkusio/code.quarkus.io/issues/424")
         val shortId: String,
+
         val version: String,
         val name: String,
         val description: String?,

--- a/src/main/kotlin/io/quarkus/code/model/CreatedProject.kt
+++ b/src/main/kotlin/io/quarkus/code/model/CreatedProject.kt
@@ -1,0 +1,5 @@
+package io.quarkus.code.model
+
+data class CreatedProject(
+        var path: String
+)

--- a/src/main/kotlin/io/quarkus/code/model/ProjectDefinition.kt
+++ b/src/main/kotlin/io/quarkus/code/model/ProjectDefinition.kt
@@ -1,11 +1,13 @@
 package io.quarkus.code.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.Pattern
 import javax.ws.rs.DefaultValue
 import javax.ws.rs.QueryParam
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 class ProjectDefinition {
 
     companion object {
@@ -13,6 +15,7 @@ class ProjectDefinition {
         const val DEFAULT_ARTIFACTID = "code-with-quarkus"
         const val DEFAULT_VERSION = "1.0.0-SNAPSHOT"
         const val DEFAULT_BUILDTOOL = "MAVEN"
+        const val DEFAULT_NO_EXAMPLES = false
 
         const val GROUPID_PATTERN = "^([a-zA-Z_\$][a-zA-Z\\d_\$]*\\.)*[a-zA-Z_\$][a-zA-Z\\d_\$]*\$"
         const val ARTIFACTID_PATTERN = "^[a-z][a-z0-9-._]*\$"
@@ -77,10 +80,10 @@ class ProjectDefinition {
     var path: String? = null
         private set
 
-    @DefaultValue("false")
+    @DefaultValue(DEFAULT_NO_EXAMPLES.toString())
     @QueryParam("ne")
     @Parameter(name = "ne", description = "No code examples", required = false)
-    var noExamples: Boolean = false
+    var noExamples: Boolean = DEFAULT_NO_EXAMPLES
         private set
 
     @DefaultValue(DEFAULT_BUILDTOOL)
@@ -92,13 +95,14 @@ class ProjectDefinition {
         private set
 
     @QueryParam("e")
-    @Parameter(name = "e", description = "The set of extension that will be included in the generated application", required = false)
+    @Parameter(name = "e", description = "The set of extension ids that will be included in the generated application", required = false)
     var extensions: Set<String> = setOf()
         private set
 
     @QueryParam("s")
     @DefaultValue("")
     @Parameter(name = "s", description = "The set of extension shortIds separated by a '.' that will be included in the generated application", required = false)
+    @Deprecated(message = "see https://github.com/quarkusio/code.quarkus.io/issues/424")
     var shortExtensions: String = ""
         private set
 

--- a/src/main/kotlin/io/quarkus/code/rest/CodeQuarkusResource.kt
+++ b/src/main/kotlin/io/quarkus/code/rest/CodeQuarkusResource.kt
@@ -4,24 +4,26 @@ import io.quarkus.code.config.CodeQuarkusConfig
 import io.quarkus.code.config.GitHubConfig
 import io.quarkus.code.config.GoogleAnalyticsConfig
 import io.quarkus.code.model.CodeQuarkusExtension
+import io.quarkus.code.model.CreatedProject
 import io.quarkus.code.model.PublicConfig
 import io.quarkus.code.model.ProjectDefinition
 import io.quarkus.code.service.QuarkusExtensionCatalogService
 import io.quarkus.code.service.QuarkusProjectService
 import io.quarkus.runtime.StartupEvent
+import org.apache.http.NameValuePair
+import org.apache.http.client.utils.URLEncodedUtils
+import org.apache.http.message.BasicNameValuePair
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.media.Content
 import org.eclipse.microprofile.openapi.annotations.media.Schema
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse
+import java.nio.charset.StandardCharsets
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.enterprise.event.Observes
 import javax.inject.Inject
 import javax.validation.Valid
-import javax.ws.rs.BeanParam
-import javax.ws.rs.GET
-import javax.ws.rs.Path
-import javax.ws.rs.Produces
+import javax.ws.rs.*
 import javax.ws.rs.core.MediaType.APPLICATION_JSON
 import javax.ws.rs.core.MediaType.TEXT_PLAIN
 import javax.ws.rs.core.Response
@@ -91,6 +93,44 @@ class CodeQuarkusResource {
     )
     fun extensions(): List<CodeQuarkusExtension> {
         return extensionCatalog.extensions
+    }
+
+    @POST
+    @Path("/project")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    @Operation(summary = "Prepare a Quarkus application project to be downloaded")
+    fun prepare(@Valid projectDefinition: ProjectDefinition?): CreatedProject {
+        val params = ArrayList<NameValuePair>();
+        if (projectDefinition != null) {
+            if(projectDefinition.groupId != ProjectDefinition.DEFAULT_GROUPID) {
+                params.add(BasicNameValuePair("g", projectDefinition.groupId))
+            }
+            if(projectDefinition.artifactId != ProjectDefinition.DEFAULT_ARTIFACTID) {
+                params.add(BasicNameValuePair("a", projectDefinition.artifactId))
+            }
+            if(projectDefinition.version != ProjectDefinition.DEFAULT_VERSION) {
+                params.add(BasicNameValuePair("v", projectDefinition.version))
+            }
+            if(projectDefinition.buildTool != ProjectDefinition.DEFAULT_BUILDTOOL) {
+                params.add(BasicNameValuePair("b", projectDefinition.buildTool))
+            }
+            if(projectDefinition.noExamples != ProjectDefinition.DEFAULT_NO_EXAMPLES) {
+                params.add(BasicNameValuePair("ne", projectDefinition.noExamples.toString()))
+            }
+            if(!projectDefinition.extensions.isEmpty()) {
+                projectDefinition.extensions.forEach { params.add(BasicNameValuePair("e", it)) }
+            }
+        }
+        val path = if(params.isEmpty()) "/d" else "/d?${URLEncodedUtils.format(params, StandardCharsets.UTF_8)}"
+       if (path.length > 1900) {
+           throw BadRequestException(Response
+               .status(Response.Status.BAD_REQUEST)
+               .entity("The path is too long. Choose a sensible amount of extensions.")
+               .type(TEXT_PLAIN)
+               .build())
+       }
+        return CreatedProject(path)
     }
 
     @GET

--- a/src/main/kotlin/io/quarkus/code/service/GitHubClient.kt
+++ b/src/main/kotlin/io/quarkus/code/service/GitHubClient.kt
@@ -1,7 +1,8 @@
 package io.quarkus.code.service
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
-import javax.json.bind.annotation.JsonbProperty
 import javax.ws.rs.*
 import javax.ws.rs.core.MediaType
 
@@ -31,15 +32,17 @@ interface GitHubClient {
     fun createRepo(@HeaderParam("Authorization") authorization: String,
                    repo: GHCreateRepo): GHRepo
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     class GHMe {
         lateinit var login: String
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     class GHRepo {
         lateinit var name: String
         var description: String? = null
 
-        @JsonbProperty("clone_url")
+        @JsonProperty("clone_url")
         lateinit var cloneUrl: String
     }
 

--- a/src/test/kotlin/io/quarkus/code/CodeQuarkusTest.kt
+++ b/src/test/kotlin/io/quarkus/code/CodeQuarkusTest.kt
@@ -53,8 +53,4 @@ class CodeQuarkusTest {
         val run = WrapperRunner.run(dir.toPath().resolve(appName), WrapperRunner.Wrapper.GRADLE)
         assertThat(run, `is`(0))
     }
-
-
-
-
 }


### PR DESCRIPTION
- Deprecate `shortId` in `/api/extensions`
- Deprecate `s` in `/api/download`
- Add POST `/api/project` to retrieve the download `path` (see openapi doc) 

Example flow with for example `apiUrl = https://code.quarkus.io` 
POST to `{apiUrl}/api/project`:
```json 
{
	"groupId": "my.group",
	"artifactId": "my-app",
	"extensions": ["io.quarkus:quarkus-resteasy", "io.quarkus:quarkus-resteasy-qute"]
}
```

returns:
```json
{
	"path": "/d?g=my.group&a=my-app&e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-resteasy-qute"
}
```

then call:
GET to `{apiUrl}{path}`

NOTES: 
 - this is not breaking anything yet (just adding the new POST method)
 - all project json fields are optionals
 - using the `GET` without calling the `POST` first is not recommended as it may evolve
 - if too many extensions are selected, you get a BAD REQUEST error
 - the old flow with shortIds will be working for a little while for transition



As part of #424