### PR TITLE
Switch to UBI OpenJDK runtime image for runner

### DIFF
--- a/src/main/docker/Dockerfile.multistage
+++ b/src/main/docker/Dockerfile.multistage
@@ -10,7 +10,7 @@ USER quarkus
 RUN cd /usr/src/app/ && mvn clean package $MAVEN_BUILD_EXTRA_ARGS
 
 ## Stage 2 : create the docker final image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.9
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ARG MAVEN_EXTRA_ARGS=
@@ -20,8 +20,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' QUARKUS_LOCAL_REPO=/tmp/.m2
 
 # Install java and the run-java script
 # Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
+RUN microdnf update \
     && microdnf clean all \
     && mkdir /deployments \
     && chown 1001 /deployments \

--- a/src/main/docker/Dockerfile.multistage
+++ b/src/main/docker/Dockerfile.multistage
@@ -11,7 +11,6 @@ RUN cd /usr/src/app/ && mvn clean package $MAVEN_BUILD_EXTRA_ARGS
 
 ## Stage 2 : create the docker final image
 FROM registry.access.redhat.com/ubi8/openjdk-11-runtime:1.9
-ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ARG MAVEN_EXTRA_ARGS=
 RUN echo "$MAVEN_EXTRA_ARGS"


### PR DESCRIPTION
The just-released UBI OpenJDK runtime image is ubi-minimal + java-<version>-openjdk-headless RPM and its dependencies which include curl and ca-certificates. Switching to these base images reduces the complexity of the Dockerfile slightly, and should slightly speed up builds. Although I've left in the "microdnf update" command. The build process for the UBI OpenJDK runtime images includes that command, so you could choose to remove it here if you wished.