### PR TITLE
Bump ubi-minimal to 8.4

### DIFF
--- a/api/src/main/docker/Dockerfile.multistage
+++ b/api/src/main/docker/Dockerfile.multistage
@@ -11,7 +11,7 @@ USER quarkus
 RUN cd /usr/src/app/ && mvn clean package $MAVEN_BUILD_EXTRA_ARGS
 
 ## Stage 2 : create the docker final image
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ARG MAVEN_EXTRA_ARGS=


### PR DESCRIPTION
This eliminates the vulnerabilities found in the security scan reported by Quay.io