### PR TITLE
Fix clear filter and shortname search

### DIFF
--- a/api/src/main/kotlin/io/quarkus/code/misc/QuarkusExtensionUtils.kt
+++ b/api/src/main/kotlin/io/quarkus/code/misc/QuarkusExtensionUtils.kt
@@ -57,7 +57,6 @@ object QuarkusExtensionUtils {
         return list
     }
 
-
     @JvmStatic
     fun toCodeQuarkusExtension(
         ext: Extension?,

--- a/library/.bitmap
+++ b/library/.bitmap
@@ -13,7 +13,13 @@
         "scope": "quarkusio.code-quarkus",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "components"
+        "rootDir": "components",
+        "nextVersion": {
+            "version": "patch",
+            "message": "",
+            "username": "Andy Damevin",
+            "email": "ia3andy@gmail.com"
+        }
     },
     "core/analytics": {
         "scope": "quarkusio.code-quarkus",

--- a/library/components/code-quarkus.tsx
+++ b/library/components/code-quarkus.tsx
@@ -8,7 +8,7 @@ import { Config, QuarkusProject } from './api/model';
 import { QuarkusBlurb } from './layout/quarkus-blurb';
 import { Api, ConfigApi, PlatformApi } from './api/code-quarkus-api';
 import { DataLoader, SentryBoundary } from '@quarkusio/code-quarkus.core.components';
-import { getQueryParams, resolveInitialProject } from './api/quarkus-project-utils';
+import { getQueryParams, resolveInitialFilterQueryParam, resolveInitialProject } from './api/quarkus-project-utils';
 import { CodeQuarkusIoHeader } from './header/code-quarkus-io-header';
 import { CodeQuarkusHeaderProps } from './header/code-quarkus-header';
 
@@ -23,6 +23,7 @@ const queryParams = getQueryParams();
 
 export function ConfiguredCodeQuarkus(props: ConfiguredCodeQuarkusProps) {
   const [ analytics, setAnalytics ] = useState<Analytics>(useAnalytics());
+  const [ filter, setFilter ] = useState(resolveInitialFilterQueryParam());
   const [ project, setProject ] = useState<QuarkusProject>(resolveInitialProject(queryParams));
 
   useEffect(() => {
@@ -35,7 +36,7 @@ export function ConfiguredCodeQuarkus(props: ConfiguredCodeQuarkusProps) {
   const Header: React.FC<CodeQuarkusHeaderProps> = props.header || CodeQuarkusIoHeader;
   const platformLoader = () => props.platformApi(props.api, project.streamKey, project.platformOnly);
   function setStreamKey(streamKey: string, platformOnly: boolean) {
-    setProject({ ...project, streamKey, platformOnly });
+    setProject((prev) => ({ ...prev, streamKey, platformOnly }));
   }
   return (
     <AnalyticsContext.Provider value={analytics}>
@@ -44,7 +45,7 @@ export function ConfiguredCodeQuarkus(props: ConfiguredCodeQuarkusProps) {
           {platform => (
             <>
               <Header streamProps={{ platform:platform, streamKey:project.streamKey, setStreamKey, platformOnly: project.platformOnly }} />
-              <QuarkusProjectFlow {...props} platform={platform} project={project} setProject={setProject} />
+              <QuarkusProjectFlow {...props} platform={platform} project={project} setProject={setProject} filter={filter} setFilter={setFilter} />
             </>
           )}
         </DataLoader>

--- a/library/components/extensions-picker/__tests__/extensions-utils.spec.tsx
+++ b/library/components/extensions-picker/__tests__/extensions-utils.spec.tsx
@@ -18,7 +18,6 @@ const entries: ExtensionEntry[] = [
     ],
     'default': false,
     'description': 'Build time CDI dependency injection',
-    'shortName': 'CDI',
     'category': 'Core',
     'platform': true,
     'order': 0,
@@ -72,7 +71,7 @@ const entries: ExtensionEntry[] = [
       'aws',
     ],
     'platform': true,
-    'shortName': 'a shortname 2',
+    'shortName': 'cdi',
     'description': 'Some description',
     'category': 'Web',
     'order': 3,
@@ -102,8 +101,8 @@ describe('search', () => {
     () => expect(search('cdi in name; tags:experimental,preview', processedEntries)).toEqual([ entries[2] ]));
   it('"cdi in name tags:experimental,preview" filters by tags contains "experimental" or "preview and cdi in name',
     () => expect(search('cdi in name tags:experimental,preview', processedEntries)).toEqual([ entries[2] ]));
-  it('"cdi" returns only the extension with cdi as shortName',
-    () => expect(search('cdi', processedEntries)).toEqual([ entries[0] ]));
+  it('"cdi" returns the extension with cdi as shortName first',
+    () => expect(search('cdi', processedEntries)).toEqual([ entries[3], entries[0], entries[1], entries[2] ]));
   it('"cdi test" is like "cdi test in name,shortname,keywords,tags,category"',
     () => expect(search('cdi test', processedEntries)).toEqual(entries));
 });

--- a/library/components/extensions-picker/extensions-picker.tsx
+++ b/library/components/extensions-picker/extensions-picker.tsx
@@ -100,10 +100,10 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
 
   useEffect(() => {
     if (filter.length > 0) {
-      const topEvents =entries.slice(0, 5).map(r => [ 'Extension', 'Display in search top 5 results', r.id ]);
+      const topEvents = entries.slice(0, 5).map(r => [ 'Extension', 'Display in search top 5 results', r.id ]);
       debouncedSearchEvent([ ...topEvents, [ 'UX', 'Search', filter ] ]);
     }
-  }, [ filter,entries, debouncedSearchEvent ]);
+  }, [ filter, entries, debouncedSearchEvent ]);
 
 
   const add = (index: number, origin: string) => {

--- a/library/components/extensions-picker/extensions-utils.ts
+++ b/library/components/extensions-picker/extensions-utils.ts
@@ -107,11 +107,13 @@ export function search(search: string, extensionValues: ExtensionValues[]): Exte
   if (!formattedSearch) {
     return extensionValues.map(v => v.extension);
   }
-  const shortNameFound = extensionValues.find(e => e.values.get('shortname') === formattedSearch);
-  if (shortNameFound) {
-    return [ shortNameFound.extension ];
+  let filtered = [ ...extensionValues ];
+  const shortNameIndex = filtered.findIndex(e => e.values.get('shortname') === formattedSearch);
+  if (shortNameIndex >= 0) {
+    const val = filtered.splice(shortNameIndex, 1);
+    filtered.unshift(val[0]);
   }
-  let filtered = extensionValues;
+
   const equalsMatches = matchAll(EQUALS_PATTERN, formattedSearch);
   for (const e of equalsMatches) {
     if (!e.groups?.expr || !e.groups?.field) {

--- a/library/components/quarkus-project/quarkus-project-edition-form.tsx
+++ b/library/components/quarkus-project/quarkus-project-edition-form.tsx
@@ -6,7 +6,6 @@ import { GenerateButton } from '../generate-project/generate-button';
 import { Config, Extension, Platform, QuarkusProject } from '../api/model';
 import {
   debouncedSyncParamsQuery,
-  resolveInitialFilterQueryParam,
   Target
 } from '../api/quarkus-project-utils';
 import { ExtensionsCart } from '../generate-project/extensions-cart';
@@ -17,6 +16,8 @@ interface CodeQuarkusFormProps {
   selectedExtensions: Extension[];
   platform: Platform;
   setProject: React.Dispatch<SetStateAction<QuarkusProject>>;
+  filter: string;
+  setFilter: React.Dispatch<SetStateAction<string>>;
   config: Config;
   api: Api;
   onSave: (target?: Target) => void;
@@ -24,8 +25,7 @@ interface CodeQuarkusFormProps {
 
 export function CodeQuarkusForm(props: CodeQuarkusFormProps) {
   const [ isProjectValid, setIsProjectValid ] = useState(isValidInfo(props.project.metadata));
-  const [ filter, setFilter ] = useState(resolveInitialFilterQueryParam());
-  const setProject = props.setProject;
+  const { setProject, filter, setFilter } = props;
 
   const setMetadata = (metadata: any) => {
     setIsProjectValid(isValidInfo(metadata));

--- a/library/components/quarkus-project/quarkus-project-flow.tsx
+++ b/library/components/quarkus-project/quarkus-project-flow.tsx
@@ -31,6 +31,8 @@ interface QuarkusProjectFlowProps extends ConfiguredCodeQuarkusProps {
   api: Api;
   project: QuarkusProject;
   setProject: React.Dispatch<SetStateAction<QuarkusProject>>;
+  filter: string;
+  setFilter: React.Dispatch<SetStateAction<string>>;
 }
 
 export function QuarkusProjectFlow(props: QuarkusProjectFlowProps) {
@@ -82,7 +84,7 @@ export function QuarkusProjectFlow(props: QuarkusProjectFlowProps) {
   
   return (
     <>
-      <CodeQuarkusForm api={props.api} project={props.project} setProject={props.setProject} config={props.config} onSave={generate} platform={props.platform} selectedExtensions={mappedExtensions.mapped}/>
+      <CodeQuarkusForm api={props.api} project={props.project} setProject={props.setProject} filter={props.filter} setFilter={props.setFilter} config={props.config} onSave={generate} platform={props.platform} selectedExtensions={mappedExtensions.mapped}/>
       {!run.error && run.status === Status.RUNNING && (
         <LoadingModal/>
       )}


### PR DESCRIPTION
- Fixes #663 
- Using the exact shortName now keeps the other results (but show the matching extension first):
![image](https://user-images.githubusercontent.com/2223984/142614478-b3d7326e-8574-45da-817f-97920382d273.png)
