### PR TITLE
Fix behaviour when clicking on the dropdown arrow for Build Tool

### DIFF
--- a/library/.bitmap
+++ b/library/.bitmap
@@ -13,7 +13,13 @@
         "scope": "quarkusio.code-quarkus",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "components"
+        "rootDir": "components",
+        "nextVersion": {
+            "version": "patch",
+            "message": "",
+            "username": "Tarcisio Coutinho",
+            "email": "tcs5cin@gmail.com"
+        }
     },
     "core/analytics": {
         "scope": "quarkusio.code-quarkus",
@@ -25,7 +31,13 @@
         "scope": "quarkusio.code-quarkus",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "core/components"
+        "rootDir": "core/components",
+        "nextVersion": {
+            "version": "patch",
+            "message": "",
+            "username": "Tarcisio Coutinho",
+            "email": "tcs5cin@gmail.com"
+        }
     },
     "core/types": {
         "scope": "quarkusio.code-quarkus",

--- a/library/components/info-picker/build-tool-select.tsx
+++ b/library/components/info-picker/build-tool-select.tsx
@@ -12,7 +12,7 @@ export const BuildToolSelect = (props: InputProps<string>) => {
     <div className="form-group form-group-select">
       <label className="form-group-label" htmlFor="buildtool" arial-label="Choose build tool"><span
         className="form-group-label-text">Build Tool</span></label>
-      <select id="buildtool" value={props.value} onChange={adaptedOnChange} className={'form-group-control'}>
+      <select id="buildtool" value={props.value} onChange={adaptedOnChange} className={'form-group-control form-group-select'}>
         <option value={'MAVEN'}>Maven</option>
         <option value={'GRADLE'}>Gradle (Preview)</option>
         <option value={'GRADLE_KOTLIN_DSL'}>Gradle with Kotlin DSL (Preview)</option>

--- a/library/components/info-picker/info-picker.scss
+++ b/library/components/info-picker/info-picker.scss
@@ -43,6 +43,7 @@
         position: absolute;
         right: 10px;
         top: 5px;
+        z-index: -1;
       }
     }
     .form-group {


### PR DESCRIPTION
* Fixes: https://github.com/quarkusio/code.quarkus.io/issues/727

@gsmet, just a question. 
I've noticed that after run `make tag-lib` the `library/.bitmap` file shows that exists changes to `quarkusio.code-quarkus/core/components@0.0.7` (but I didn't change anything in core components).