### PR TITLE
Remove Gradle preview label from dropdown list

### DIFF
--- a/library/components/info-picker/build-tool-select.tsx
+++ b/library/components/info-picker/build-tool-select.tsx
@@ -14,8 +14,8 @@ export const BuildToolSelect = (props: InputProps<string>) => {
         className="form-group-label-text">Build Tool</span></label>
       <select id="buildtool" value={props.value} onChange={adaptedOnChange} className={'form-group-control'}>
         <option value={'MAVEN'}>Maven</option>
-        <option value={'GRADLE'}>Gradle (Preview)</option>
-        <option value={'GRADLE_KOTLIN_DSL'}>Gradle with Kotlin DSL (Preview)</option>
+        <option value={'GRADLE'}>Gradle</option>
+        <option value={'GRADLE_KOTLIN_DSL'}>Gradle with Kotlin DSL</option>
       </select>
       <FaAngleDown />
     </div>


### PR DESCRIPTION
This removes the preview label on gradle in the build tool drop down list