### PR TITLE
Switch to io.quarkus.maven.dependency API from io.quarkus.maven

### DIFF
--- a/api/src/main/kotlin/io/quarkus/code/misc/QuarkusExtensionUtils.kt
+++ b/api/src/main/kotlin/io/quarkus/code/misc/QuarkusExtensionUtils.kt
@@ -2,7 +2,7 @@ package io.quarkus.code.misc
 
 import com.google.common.collect.Lists
 import io.quarkus.code.model.CodeQuarkusExtension
-import io.quarkus.maven.ArtifactCoords
+import io.quarkus.maven.dependency.ArtifactCoords
 import io.quarkus.platform.catalog.processor.CatalogProcessor.getProcessedCategoriesInOrder
 import io.quarkus.platform.catalog.processor.ExtensionProcessor
 import io.quarkus.registry.catalog.Category


### PR DESCRIPTION
I'll be deprecating and moving towards the unified artifact API under `io.quarkus.maven.dependency` in the near future.