### PR TITLE
Introduce io.quarkus.code.java-version config

### DIFF
--- a/api/src/main/kotlin/io/quarkus/code/config/CodeQuarkusConfig.kt
+++ b/api/src/main/kotlin/io/quarkus/code/config/CodeQuarkusConfig.kt
@@ -1,8 +1,10 @@
 package io.quarkus.code.config
 
+import io.quarkus.code.model.ProjectDefinition
 import io.smallrye.config.ConfigMapping
+import io.smallrye.config.WithDefault
 import io.smallrye.config.WithName
-import java.util.*
+import java.util.Optional
 
 @ConfigMapping(prefix = "io.quarkus.code")
 interface CodeQuarkusConfig {
@@ -11,6 +13,10 @@ interface CodeQuarkusConfig {
 
     @get:WithName("quarkus-devtools-version")
     val quarkusDevtoolsVersion: String
+
+    @get:WithName("java-version")
+    @get:WithDefault(ProjectDefinition.DEFAULT_JAVA_VERSION)
+    val javaVersion: String
 
     @get:WithName("git-commit-id")
     val gitCommitId: String

--- a/api/src/main/kotlin/io/quarkus/code/model/ProjectDefinition.kt
+++ b/api/src/main/kotlin/io/quarkus/code/model/ProjectDefinition.kt
@@ -173,7 +173,7 @@ class ProjectDefinition {
         result = 31 * result + noExamples.hashCode()
         result = 31 * result + noCode.hashCode()
         result = 31 * result + buildTool.hashCode()
-        result = 31 * result + javaVersion.hashCode()
+        result = 31 * result + (javaVersion?.hashCode() ?: 0)
         result = 31 * result + extensions.hashCode()
         return result
     }

--- a/api/src/main/kotlin/io/quarkus/code/model/PublicConfig.kt
+++ b/api/src/main/kotlin/io/quarkus/code/model/PublicConfig.kt
@@ -10,5 +10,6 @@ data class PublicConfig(
     val quarkusVersion: String,
     val gitHubClientId: String?,
     val features: List<String>,
-    val gitCommitId: String?
+    val gitCommitId: String?,
+    var javaVersion: String
 )

--- a/api/src/main/kotlin/io/quarkus/code/rest/CodeQuarkusHealthCheck.kt
+++ b/api/src/main/kotlin/io/quarkus/code/rest/CodeQuarkusHealthCheck.kt
@@ -20,12 +20,11 @@ class CodeQuarkusHealthCheck : HealthCheck {
     internal lateinit var platformService: PlatformService
 
     @Inject
-    internal var projectCreator: QuarkusProjectService? = null
+    internal lateinit var projectCreator: QuarkusProjectService
 
     override fun call(): HealthCheckResponse {
         val responseBuilder = HealthCheckResponse.named("Code Quarkus HealthCheck")
-        if(platformService.isLoaded
-            && projectCreator != null) {
+        if(platformService.isLoaded) {
                     responseBuilder
                         .withData("cache last updated", platformService.cacheLastUpdated.toString())
                         .withData("registry timestamp", platformService.platformsCache.platformTimestamp)

--- a/api/src/main/kotlin/io/quarkus/code/rest/CodeQuarkusResource.kt
+++ b/api/src/main/kotlin/io/quarkus/code/rest/CodeQuarkusResource.kt
@@ -66,6 +66,7 @@ class CodeQuarkusResource {
                 quarkusDevtoolsVersion = ${config().quarkusDevtoolsVersion},
                 gitCommitId: ${config().gitCommitId},
                 features: ${config().features}
+                javaVersion: ${config().javaVersion}
         """.trimIndent()
         }
     }
@@ -85,7 +86,8 @@ class CodeQuarkusResource {
             quarkusVersion= config.quarkusPlatformVersion,
             gitCommitId = config.gitCommitId,
             gitHubClientId = gitHubConfig.clientId.filter(String::isNotBlank).orElse(null),
-            features = config.features.map { listOf(it) }.orElse(listOf())
+            features = config.features.map { listOf(it) }.orElse(listOf()),
+            javaVersion = config.javaVersion
         )
     }
 
@@ -212,7 +214,7 @@ class CodeQuarkusResource {
             if (projectDefinition.buildTool != ProjectDefinition.DEFAULT_BUILDTOOL) {
                 params.add(BasicNameValuePair("b", projectDefinition.buildTool))
             }
-            if (projectDefinition.javaVersion != ProjectDefinition.DEFAULT_JAVA_VERSION) {
+            if (projectDefinition.javaVersion != null && projectDefinition.javaVersion != config.javaVersion) {
                 params.add(BasicNameValuePair("j", projectDefinition.javaVersion))
             }
             if (projectDefinition.noCode != ProjectDefinition.DEFAULT_NO_CODE || projectDefinition.noExamples != ProjectDefinition.DEFAULT_NO_CODE) {

--- a/library/components/api/model.ts
+++ b/library/components/api/model.ts
@@ -69,6 +69,7 @@ export interface Config {
   gitCommitId: string;
   gitHubClientId?: string;
   features: string[];
+  javaVersion: string;
 }
 
 

--- a/library/components/api/quarkus-project-utils.ts
+++ b/library/components/api/quarkus-project-utils.ts
@@ -1,6 +1,6 @@
 import { parse, ParsedUrlQuery, stringify } from 'querystring';
 import { createGitHubProject } from './code-quarkus-github-api';
-import { Extension, PlatformMappedExtensions, QuarkusProject } from './model';
+import {Config, Extension, PlatformMappedExtensions, QuarkusProject} from './model';
 import _ from 'lodash';
 import { Api } from './code-quarkus-api';
 
@@ -147,14 +147,14 @@ export const createOnGitHub = (api: Api, project: QuarkusProject, clientId: stri
   window.location.href = githubAuthorizeUrl;
 };
 
-export function newDefaultProject(): QuarkusProject {
+export function newDefaultProject(config? : Config): QuarkusProject {
   return ({
     metadata: {
       groupId: 'org.acme',
       artifactId: 'code-with-quarkus',
       version: '1.0.0-SNAPSHOT',
       buildTool: 'MAVEN',
-      javaVersion: '17',
+      javaVersion: config?.javaVersion || '17',
       noCode: false
     },
     extensions: [],
@@ -239,8 +239,8 @@ const generateParamQuery = (filter: string, project: string) => {
   return '';
 };
 
-export function resolveInitialProject(queryParams?: ParsedUrlQuery) {
-  return parseProjectInQuery(queryParams) || retrieveProjectFromLocalStorage() || newDefaultProject();
+export function resolveInitialProject(queryParams?: ParsedUrlQuery, config?: Config) {
+  return parseProjectInQuery(queryParams) || retrieveProjectFromLocalStorage() || newDefaultProject(config);
 }
 
 function normalizeQueryExtensions(queryExtensions: undefined | string | string[]): Set<string> {

--- a/library/components/code-quarkus.tsx
+++ b/library/components/code-quarkus.tsx
@@ -24,7 +24,7 @@ const queryParams = getQueryParams();
 export function ConfiguredCodeQuarkus(props: ConfiguredCodeQuarkusProps) {
   const [ analytics, setAnalytics ] = useState<Analytics>(useAnalytics());
   const [ filter, setFilter ] = useState(resolveInitialFilterQueryParam());
-  const [ project, setProject ] = useState<QuarkusProject>(resolveInitialProject(queryParams));
+  const [ project, setProject ] = useState<QuarkusProject>(resolveInitialProject(queryParams, props. config));
 
   useEffect(() => {
     setAnalytics((prev) => {

--- a/openshift/code-quarkus-api.yaml
+++ b/openshift/code-quarkus-api.yaml
@@ -113,6 +113,8 @@ objects:
                       name: secrets
                       key: ga-tracking-id
                       optional: true
+                - name: IO_QUARKUS_CODE_JAVA_VERSION
+                  value: ${IO_QUARKUS_CODE_JAVA_VERSION}
               envFrom:
                 - configMapRef:
                     name: code-quarkus-api-registry
@@ -135,6 +137,7 @@ objects:
       sessionAffinity: None
       type: ClusterIP
 parameters:
+  - name: IO_QUARKUS_CODE_JAVA_VERSION
   - name: IO_QUARKUS_CODE_ENVIRONMENT
   - name: IO_QUARKUS_CODE_FEATURES
   - name: IO_QUARKUS_CODE_HOSTNAME


### PR DESCRIPTION
This PR introduces a `io.quarkus.code.java-version` config property that allows setting the default Java version to be used. 

It allows us to set the production instance to use JDK 11 by default as requested in https://issues.redhat.com/browse/QUARKUS-2451
