### PR TITLE
Add supported-by information for extension descriptors

### DIFF
--- a/api/src/main/kotlin/io/quarkus/code/misc/QuarkusExtensionUtils.kt
+++ b/api/src/main/kotlin/io/quarkus/code/misc/QuarkusExtensionUtils.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 object QuarkusExtensionUtils {
 
-    val TAG_KEYS = listOf("status", ".+-support", "with")
+    val TAG_KEYS = listOf("status", "with", "supported-by")
 
     fun toShortcut(id: String): String = id.replace(Regex("^([^:]+:)?(quarkus-)?"), "")
 
@@ -68,7 +68,12 @@ object QuarkusExtensionUtils {
         val data = extension.syntheticMetadata
         for (entry in data.entries) {
             if (TAG_KEYS.any { Regex(it).matches(entry.key) } && !entry.value.isEmpty()) {
-                tags.add(entry.key + ":" + entry.value.first())
+                if ("supported-by".equals(entry.key)) {
+                    val key = entry.value.first() + "-support"
+                    tags.add(key + ":" + data.get(key)?.first())
+                } else {
+                    tags.add(entry.key + ":" + entry.value.first())
+                }
             }
         }
         return tags;

--- a/api/src/test/kotlin/io/quarkus/code/misc/QuarkusExtensionUtilsTest.kt
+++ b/api/src/test/kotlin/io/quarkus/code/misc/QuarkusExtensionUtilsTest.kt
@@ -37,7 +37,7 @@ internal class QuarkusExtensionUtilsTest {
                     description = "REST endpoint framework implementing JAX-RS and more",
                     shortName = "jax-rs",
                     category = "Web",
-                    tags = listOf("with:starter-code", "status:stable"),
+                    tags = listOf("with:starter-code", "redhat-support:stable", "status:stable"),
                     keywords = setOf("endpoint", "framework", "jax", "jaxrs", "jax-rs", "quarkus-resteasy", "rest", "resteasy", "web"),
                     providesExampleCode = true,
                     providesCode = true,

--- a/api/src/test/resources/fakeextensions.json
+++ b/api/src/test/resources/fakeextensions.json
@@ -960,6 +960,8 @@
       "guide" : "https://quarkus.io/guides/rest-json",
       "categories" : [ "web" ],
       "status" : "stable",
+      "supported-by" : "redhat",
+      "redhat-support" : "stable",
       "codestart" : {
         "name" : "resteasy",
         "languages" : [ "java", "kotlin", "scala" ],


### PR DESCRIPTION
In support of [#8021](https://github.com/quarkusio/quarkus/issues/8021), process the supported-by attribute to find a supporter name, then find an attribute with the supporter name with the suffix of `-status` to find the status for the extension supporter.

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>