### PR TITLE
JAVA_OPTS → JAVA_OPTS_APPEND, bump FROM version

### DIFF
--- a/api/src/main/docker/Dockerfile.multistage
+++ b/api/src/main/docker/Dockerfile.multistage
@@ -1,5 +1,5 @@
 ## Stage 1 : build with maven builder image
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14 AS build
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17 AS build
 ARG MAVEN_BUILD_EXTRA_ARGS=
 RUN echo "$MAVEN_BUILD_EXTRA_ARGS"
 COPY mvnw pom.xml maven-settings.xml* /usr/src/app/
@@ -12,7 +12,7 @@ USER 185
 RUN cd /usr/src/app/ && ./mvnw clean package $MAVEN_BUILD_EXTRA_ARGS
 
 ## Stage 2 : create the docker final image
-FROM registry.access.redhat.com/ubi8/openjdk-17:1.14
+FROM registry.access.redhat.com/ubi8/openjdk-17:1.17
 
 ARG MAVEN_EXTRA_ARGS=
 RUN echo "$MAVEN_EXTRA_ARGS"
@@ -32,5 +32,5 @@ COPY --from=build --chown=185 usr/src/app/target/quarkus-app/quarkus/ /deploymen
 EXPOSE 8080
 USER 185
 ENV AB_JOLOKIA_OFF=""
-ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dfile.encoding=UTF-8 $MAVEN_EXTRA_ARGS"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dfile.encoding=UTF-8 $MAVEN_EXTRA_ARGS"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"


### PR DESCRIPTION
The ENV JAVA_OPTS here is a configuration parameter for the base image ubi8/openjdk-17. In version :1.14, a bug prevented it from behaving as intended:  JAVA_OPTS is supposed to override all JVM tuning options from the run script, but it only overrode some of them.

Version :1.17 and newer of the ubi8/openjdk-17 container image changes the behaviour of JAVA_OPTS to properly override all run script parameters.

This was noticed in
<https://github.com/quarkusio/quarkus/issues/35863>

The alternative variable JAVA_OPTS_APPEND is intended to provide extra parameters on top of those generated by the run script.

Switch to using JAVA_OPTS_APPEND instead of JAVA_OPTS. Take the opportunity to update to the latest base image version (:1.17).