### PR TITLE
Additional Presets

### DIFF
--- a/base/src/main/java/io/quarkus/code/config/CodeQuarkusConfig.java
+++ b/base/src/main/java/io/quarkus/code/config/CodeQuarkusConfig.java
@@ -1,5 +1,6 @@
 package io.quarkus.code.config;
 
+import java.util.List;
 import java.util.Optional;
 
 import io.smallrye.config.ConfigMapping;
@@ -20,4 +21,6 @@ public interface CodeQuarkusConfig {
     Optional<String> hostname();
 
     UIConfig ui();
+
+    List<PresetConfig> presets();
 }

--- a/base/src/main/java/io/quarkus/code/config/PresetConfig.java
+++ b/base/src/main/java/io/quarkus/code/config/PresetConfig.java
@@ -1,0 +1,14 @@
+package io.quarkus.code.config;
+
+import java.util.List;
+
+public interface PresetConfig {
+
+    String key();
+
+    String title();
+
+    String icon();
+
+    List<String> extensions();
+}

--- a/base/src/main/java/io/quarkus/code/rest/CodeQuarkusResource.java
+++ b/base/src/main/java/io/quarkus/code/rest/CodeQuarkusResource.java
@@ -174,12 +174,20 @@ public class CodeQuarkusResource {
 
     private Uni<Response> presets(Map<String, ExtensionRef> extensionsById) {
         String lastUpdated = platformService.cacheLastUpdated().format(FORMATTER);
-        final List<Preset> presets = PRESETS.stream().filter(p -> p.extensions().stream().allMatch(extensionsById::containsKey))
+        final List<Preset> presets = getAllPresets().stream()
+                .filter(p -> p.extensions().stream().allMatch(extensionsById::containsKey))
                 .toList();
         Response response = Response.ok(presets)
                 .header(LAST_MODIFIED_HEADER, lastUpdated)
                 .build();
         return Uni.createFrom().item(response);
+    }
+
+    List<Preset> getAllPresets() {
+        List<Preset> presets = new ArrayList<>(PRESETS);
+        config.presets().stream().map(presetConfig -> new Preset(presetConfig.key(), presetConfig.title(), presetConfig.icon(),
+                presetConfig.extensions())).forEach(presets::add);
+        return presets;
     }
 
     private Uni<Response> extensions(


### PR DESCRIPTION
Provides the ability to express additional presets in configuration
Fixes https://github.com/quarkusio/code.quarkus.io/issues/1480
The current approach is to keep the default presets as a constant, and to allow defining more presets in configuration.
This allows appending presets to the existing one, and not just replace them.
If we want to move the `PRESETS` constant to configuration, then we would need 2 config variables `presets` and `additional-presets`.
see also this [zulip thread](https://quarkusio.zulipchat.com/#narrow/channel/187030-users/topic/custom.20create.20app.20scaffolding).
cc @ia3andy 