### PR TITLE
Use official java action, allow dependabot to suggest actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,13 @@ updates:
         - "quarkus*"
         - "org.mvnpm*"
         - "io.quarkiverse*"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "06:30"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 2
+  labels:
+    - infra
+  rebase-strategy: disabled

--- a/.github/workflows/build.actions.yml
+++ b/.github/workflows/build.actions.yml
@@ -18,11 +18,10 @@ jobs:
       - uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up JDK 21
-        # Uses sha for added security since tags can be updated
-        uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+      - uses: actions/setup-java@v5
         with:
-          java-version: openjdk21
+          distribution: temurin
+          java-version: 21
       - name: Cache Maven Repository
         id: cache-maven
         uses: actions/cache@v4


### PR DESCRIPTION
I noticed we're using a non-official action for setting up Java. We tend to prefer ones from official sources, for security reasons. 

I also spotted some old versions of actions. Rather than update them myself, I thought we should let dependabot do it. As part of that change, we'd need to create an 'infra' label, which I don't have permissions to do.