### PR TITLE
Add the possibility to add tag namespace 

### DIFF
--- a/base/src/main/resources/web/community-app/theme.scss
+++ b/base/src/main/resources/web/community-app/theme.scss
@@ -86,7 +86,6 @@
   // Extensions picker
   --originPlatformColor: #cd54e1;
 
-
   --extensionsPickerTextColor: var(--mainContainerTextColor);
   --extensionsPickerIdTextColor: var(--primary);
   --extensionsPickerListBg: var(--background3);
@@ -168,4 +167,9 @@
   --blurbTextColor: var(--textColor);;
   --blurbLinkTextColor: var(--linkTextColor);
   --blurbInfoIconColor: var(--primary);
+
+  // Tags namespace
+  --tagNameColor: var(--primary);
+  --tagNameBackground: var(--background2);
+  --tagNameBorder: none; // Use format: "1px solid #color" for borders
 }

--- a/base/src/main/resources/web/lib/components/extensions-picker/extension-row.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extension-row.tsx
@@ -75,7 +75,7 @@ export function ExtensionRow(props: ExtensionRowProps) {
         <span className="extension-name" title={`${props.name} (${props.version})`}>{props.name}</span>
         <span className="extension-id" title={props.id}> [{id}]</span>
         <ExtensionsOrigin platform={props.platform} />
-        {props.tags && props.tags.map((s, i) => <ExtensionTags key={i} tagsDef={props.tagsDef} name={s} hover={hover}/>)}
+        <ExtensionTags tags={props.tags} tagsDef={props.tagsDef} hover={hover} />
       </div>
 
       {props.layout === 'cart' && !props.transitive && (

--- a/base/src/main/resources/web/lib/components/extensions-picker/extension-tag.scss
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extension-tag.scss
@@ -1,0 +1,20 @@
+.extension-tag {
+  &-name {
+    border-top-left-radius: 20px;
+    border-bottom-left-radius: 20px;
+    padding: 0 7px;
+    background-color: var(--tagNameBackground);
+    color: var(--tagNameColor);
+    border: var(--tagNameBorder);
+  }
+
+  &-value {
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
+    padding: 0 7px;
+  }
+
+  &-full-name {
+    padding: 0;
+  }
+}

--- a/base/src/main/resources/web/lib/components/extensions-picker/extension-tag.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extension-tag.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { TagEntry } from './extensions-picker';
+import { Dropdown } from 'react-bootstrap';
+import { HoverControlledDropdown } from '../../core/components';
+
+export function ExtensionTag(props: { name: string; tagsDef: TagEntry[]; hover: boolean }) {
+  const tagDef = props.tagsDef.find(t => t.name === props.name) || {
+    name: props.name,
+    color: 'black'
+  }
+  if (tagDef.hide) {
+    return <React.Fragment/>;
+  }
+  let s = props.name.split(':');
+  const key = s.length > 1 ? s[1] : s[0];
+  const tag = (
+    <
+    >
+      {key.toUpperCase()}
+    </>
+  );
+  const tooltip = !props.hover ? '': (
+    <>
+      [{props.name}] - {tagDef.description}
+      {!!tagDef.href && (
+        <>
+          {tagDef.description && <br/>}
+          <a onClick={(e) => e.stopPropagation()} href={tagDef.href} target="_blank" rel="noopener noreferrer" >More info...</a>
+        </>
+      )}
+    </>
+  );
+
+  const style: {border?: string; backgroundColor?: string; color?: string} = {};
+  if (tagDef.border) {
+    style.border = '1px solid ' + tagDef.border;
+  }
+
+  if (tagDef.background) {
+    style.backgroundColor = tagDef.background;
+  }
+
+  if (tagDef.color) {
+    style.color = tagDef.color;
+  }
+
+  return (
+    <HoverControlledDropdown
+      className="extension-tag-dropdown"
+      placement="right"
+      delay={{ show: 200, hide: 0 }}
+    >
+      <Dropdown.Toggle as="div"
+        className={`extension-tag ${props.name.toLowerCase().replace(":", "-")}`}
+        style={style}>{tag}</Dropdown.Toggle>
+      <Dropdown.Menu>{tooltip}</Dropdown.Menu>
+    </HoverControlledDropdown>
+  );
+}

--- a/base/src/main/resources/web/lib/components/extensions-picker/extension-tag.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extension-tag.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { TagEntry } from './extensions-picker';
 import { Dropdown } from 'react-bootstrap';
 import { HoverControlledDropdown } from '../../core/components';
+import './extension-tag.scss';
 
 export function ExtensionTag(props: { name: string; tagsDef: TagEntry[]; hover: boolean }) {
   const tagDef = props.tagsDef.find(t => t.name === props.name) || {
@@ -13,12 +14,35 @@ export function ExtensionTag(props: { name: string; tagsDef: TagEntry[]; hover: 
   }
   let s = props.name.split(':');
   const key = s.length > 1 ? s[1] : s[0];
-  const tag = (
-    <
-    >
-      {key.toUpperCase()}
-    </>
-  );
+  const displayText = tagDef.showFullName ? props.name : key;
+
+  // Check if we should render with full name (name:value split)
+  const hasFullName = tagDef.showFullName && s.length > 1;
+
+  let tag;
+  if (hasFullName) {
+    const valueStyle: {backgroundColor?: string; color?: string} = {};
+    if (tagDef.background) {
+      valueStyle.backgroundColor = tagDef.background;
+    }
+    if (tagDef.color) {
+      valueStyle.color = tagDef.color;
+    }
+
+    tag = (
+      <>
+        <span className="extension-tag-name">{s[0].toUpperCase()}</span>
+        <span className="extension-tag-value" style={valueStyle}>{s[1].toUpperCase()}</span>
+      </>
+    );
+  } else {
+    tag = (
+      <>
+        {displayText.toUpperCase()}
+      </>
+    );
+  }
+
   const tooltip = !props.hover ? '': (
     <>
       [{props.name}] - {tagDef.description}
@@ -36,13 +60,18 @@ export function ExtensionTag(props: { name: string; tagsDef: TagEntry[]; hover: 
     style.border = '1px solid ' + tagDef.border;
   }
 
-  if (tagDef.background) {
-    style.backgroundColor = tagDef.background;
+  // Only apply single-color styles if not using full name mode
+  if (!hasFullName) {
+    if (tagDef.background) {
+      style.backgroundColor = tagDef.background;
+    }
+
+    if (tagDef.color) {
+      style.color = tagDef.color;
+    }
   }
 
-  if (tagDef.color) {
-    style.color = tagDef.color;
-  }
+  const containerClass = `extension-tag ${props.name.toLowerCase().replace(":", "-")}${hasFullName ? ' extension-tag-full-name' : ''}`;
 
   return (
     <HoverControlledDropdown
@@ -51,7 +80,7 @@ export function ExtensionTag(props: { name: string; tagsDef: TagEntry[]; hover: 
       delay={{ show: 200, hide: 0 }}
     >
       <Dropdown.Toggle as="div"
-        className={`extension-tag ${props.name.toLowerCase().replace(":", "-")}`}
+        className={containerClass}
         style={style}>{tag}</Dropdown.Toggle>
       <Dropdown.Menu>{tooltip}</Dropdown.Menu>
     </HoverControlledDropdown>

--- a/base/src/main/resources/web/lib/components/extensions-picker/extension-tags.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extension-tags.tsx
@@ -1,62 +1,16 @@
 import React from 'react';
 import { TagEntry } from './extensions-picker';
-import { Dropdown } from 'react-bootstrap';
-import { HoverControlledDropdown } from '../../core/components';
+import { ExtensionTag } from './extension-tag';
 
-export function ExtensionTags(props: { name?: string; tagsDef: TagEntry[]; hover: boolean }) {
-  if (!props.name) {
+export function ExtensionTags(props: { tags?: string[]; tagsDef: TagEntry[]; hover: boolean }) {
+  if (!props.tags || props.tags.length === 0) {
     return <React.Fragment/>;
   }
-  const tagDef = props.tagsDef.find(t => t.name === props.name) || {
-    name: props.name,
-    color: 'black'
-  }
-  if (tagDef.hide) {
-    return <React.Fragment/>;
-  }
-  let s = props.name.split(':');
-  const key = s.length > 1 ? s[1] : s[0];
-  const tag = (
-    <
-    >
-      {key.toUpperCase()}
-    </>
-  );
-  const tooltip = !props.hover ? '': (
-    <>
-      [{props.name}] - {tagDef.description}
-      {!!tagDef.href && (
-        <> 
-          {tagDef.description && <br/>}
-          <a onClick={(e) => e.stopPropagation()} href={tagDef.href} target="_blank" rel="noopener noreferrer" >More info...</a>
-        </>
-      )}
-    </>
-  );
-
-  const style: {border?: string; backgroundColor?: string; color?: string} = {};
-  if (tagDef.border) {
-    style.border = '1px solid ' + tagDef.border;
-  }
-
-  if (tagDef.background) {
-    style.backgroundColor = tagDef.background;
-  }
-
-  if (tagDef.color) {
-    style.color = tagDef.color;
-  }
-
   return (
-    <HoverControlledDropdown
-      className="extension-tag-dropdown"
-      placement="right"
-      delay={{ show: 200, hide: 0 }}
-    >
-      <Dropdown.Toggle as="div"
-        className={`extension-tag ${props.name.toLowerCase().replace(":", "-")}`}
-        style={style}>{tag}</Dropdown.Toggle>
-      <Dropdown.Menu>{tooltip}</Dropdown.Menu>
-    </HoverControlledDropdown>
+    <>
+      {props.tags.map((tag, i) => (
+        <ExtensionTag key={i} name={tag} tagsDef={props.tagsDef} hover={props.hover} />
+      ))}
+    </>
   );
 }

--- a/base/src/main/resources/web/lib/components/extensions-picker/extensions-picker.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extensions-picker.tsx
@@ -40,6 +40,7 @@ export interface TagEntry {
   border?: string;
   background?: string;
   hide?: boolean;
+  showFullName?: boolean;
 }
 
 export interface ExtensionsPickerValue {


### PR DESCRIPTION
The goal is to provide a way for chosen tags to add the namespace before the value. In some cases we want to add some visual clarity in what is shown in the tags.

To use this feature you need to:
* Ensure you have in your theme.scss the following vars:
```
  --tagNameColor: var(--primary);
  --tagNameBackground: var(--background2);
  --tagNameBorder: none;
```
* Add `showFullName: true` in your tag definition customization

This look like the following when tested for support tags on the camel custom site:

<img width="1558" height="456" alt="Capture d’écran du 2026-04-30 17-51-56" src="https://github.com/user-attachments/assets/9b5ebe27-4986-45c7-8502-8a4123ef0c35" />

Note: I did some refactoring by separating to a list and item components for tags.