### PR TITLE
Add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.actions.yml
+++ b/.github/workflows/release.actions.yml
@@ -19,6 +19,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- The JReleaser step needs `contents: write` permission to create GitHub releases now that default token permissions have been reduced at the repo level.