### PR TITLE
Tags: Add a tag for each value in the metadata array

### DIFF
--- a/base/src/main/java/io/quarkus/code/misc/QuarkusExtensionUtils.java
+++ b/base/src/main/java/io/quarkus/code/misc/QuarkusExtensionUtils.java
@@ -77,7 +77,9 @@ public class QuarkusExtensionUtils {
         var data = extension.getSyntheticMetadata();
         for (var entry : data.entrySet()) {
             if (TAG_KEYS.stream().anyMatch(it -> entry.getKey().matches(it)) && !entry.getValue().isEmpty()) {
-                tags.add(entry.getKey() + ":" + entry.getValue().iterator().next());
+                for (String value : entry.getValue()) {
+                    tags.add(entry.getKey() + ":" + value);
+                }
             }
         }
         return tags;


### PR DESCRIPTION
Taking only the first value is not enough for multivalued field.

In our case, redhat-camel-support is multivalued.