### PR TITLE
Prepare for next development iteration (75-SNAPSHOT)

### DIFF
--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>74-SNAPSHOT</version>
+        <version>75-SNAPSHOT</version>
     </parent>
     <properties>
         <maven.compiler.release>17</maven.compiler.release>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>74-SNAPSHOT</version>
+        <version>75-SNAPSHOT</version>
     </parent>
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/community-app/pom.xml
+++ b/community-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>74-SNAPSHOT</version>
+        <version>75-SNAPSHOT</version>
     </parent>
 
     <artifactId>code-quarkus-community-app</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus.code</groupId>
     <artifactId>code-quarkus-parent</artifactId>
-    <version>74-SNAPSHOT</version>
+    <version>75-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
         <code-quarkus.version>${project.version}</code-quarkus.version>

--- a/web-deps/locker/pom.xml
+++ b/web-deps/locker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkus.code</groupId>
     <artifactId>code-quarkus-parent</artifactId>
-    <version>74-SNAPSHOT</version>
+    <version>75-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>code-quarkus-web-deps-locker</artifactId>

--- a/web-deps/pom.xml
+++ b/web-deps/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>74-SNAPSHOT</version>
+        <version>75-SNAPSHOT</version>
     </parent>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
v74 was already published to Maven Central but the version bump was never pushed due to a JReleaser failure. Bumping to 75-SNAPSHOT.