### PR TITLE
Customize Konflux pipeline definitions

### DIFF
--- a/.tekton/code-quarkus-acceptance-test-pull-request.yaml
+++ b/.tekton/code-quarkus-acceptance-test-pull-request.yaml
@@ -9,7 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/code-quarkus-acceptance-test-**".pathChanged() || "acceptance-test/**".pathChanged()
+      || "docker/Dockerfile.acceptance-test.multistage".pathChanged() || "pom.xml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: code-quarkus-community

--- a/.tekton/code-quarkus-acceptance-test-push.yaml
+++ b/.tekton/code-quarkus-acceptance-test-push.yaml
@@ -8,7 +8,9 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && !body.head_commit.message.startsWith("Bump") && (".tekton/code-quarkus-acceptance-test-**".pathChanged()
+      || "acceptance-test/**".pathChanged() || "docker/Dockerfile.acceptance-test.multistage".pathChanged()
+      || "pom.xml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: code-quarkus-community
@@ -24,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/quarkus/code-quarkus-acceptance-test:{{revision}}
+  - name: build-args
+    value:
+    - MAVEN_BUILD_EXTRA_ARGS=-Dgit.commit.id={{revision}}
   - name: dockerfile
     value: docker/Dockerfile.acceptance-test.multistage
   - name: path-context
@@ -447,6 +452,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - latest
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/code-quarkus-app-pull-request.yaml
+++ b/.tekton/code-quarkus-app-pull-request.yaml
@@ -9,7 +9,9 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && (".tekton/code-quarkus-app-**".pathChanged() || "base/**".pathChanged()
+      || "web-deps/**".pathChanged() || "community-app/**".pathChanged() || "docker/Dockerfile.community-app.multistage".pathChanged()
+      || "pom.xml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: code-quarkus-community

--- a/.tekton/code-quarkus-app-push.yaml
+++ b/.tekton/code-quarkus-app-push.yaml
@@ -8,7 +8,9 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && !body.head_commit.message.startsWith("Bump") && (".tekton/code-quarkus-app-**".pathChanged()
+      || "base/**".pathChanged() || "web-deps/**".pathChanged() || "community-app/**".pathChanged()
+      || "docker/Dockerfile.community-app.multistage".pathChanged() || "pom.xml".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: code-quarkus-community
@@ -24,6 +26,9 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/quarkus/code-quarkus-app:{{revision}}
+  - name: build-args
+    value:
+    - MAVEN_BUILD_EXTRA_ARGS=-Dgit.commit.id={{revision}}
   - name: dockerfile
     value: docker/Dockerfile.community-app.multistage
   - name: path-context
@@ -447,6 +452,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - latest
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Summary
- Redirect PR pipeline images to Konflux-managed repos to avoid pushing to production Quay during PRs
- Add CEL path filters so each component only rebuilds when its relevant files change
- Skip Dependabot bump commits on push pipelines
- Pass `git.commit.id` as build arg to Dockerfiles (replaces the old deploy script behavior)