### PR TITLE
Prepare for next development iteration (76-SNAPSHOT)

### DIFF
--- a/acceptance-test/pom.xml
+++ b/acceptance-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>75-SNAPSHOT</version>
+        <version>76-SNAPSHOT</version>
     </parent>
     <properties>
         <maven.compiler.release>17</maven.compiler.release>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>75-SNAPSHOT</version>
+        <version>76-SNAPSHOT</version>
     </parent>
     <properties>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/community-app/pom.xml
+++ b/community-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>75-SNAPSHOT</version>
+        <version>76-SNAPSHOT</version>
     </parent>
 
     <artifactId>code-quarkus-community-app</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus.code</groupId>
     <artifactId>code-quarkus-parent</artifactId>
-    <version>75-SNAPSHOT</version>
+    <version>76-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
         <code-quarkus.version>${project.version}</code-quarkus.version>

--- a/web-deps/locker/pom.xml
+++ b/web-deps/locker/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkus.code</groupId>
     <artifactId>code-quarkus-parent</artifactId>
-    <version>75-SNAPSHOT</version>
+    <version>76-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <artifactId>code-quarkus-web-deps-locker</artifactId>

--- a/web-deps/pom.xml
+++ b/web-deps/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.quarkus.code</groupId>
         <artifactId>code-quarkus-parent</artifactId>
-        <version>75-SNAPSHOT</version>
+        <version>76-SNAPSHOT</version>
     </parent>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary
- Bump version from 75-SNAPSHOT to 76-SNAPSHOT
- v75 was already released to Maven Central on May 5, but the version bump commit was never pushed back to main
- The nightly Release CI cron keeps failing because it tries to re-publish v75 which already exists on Central