### PR TITLE
Add noWrapper, noDockerfiles, and codestartData to project generation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ nb-configuration.xml
 # OSX
 .DS_Store
 
+# Claude Code
+CLAUDE.md
+
 # Vim
 *.swp
 *.swo

--- a/base/src/main/java/io/quarkus/code/model/ProjectDefinition.java
+++ b/base/src/main/java/io/quarkus/code/model/ProjectDefinition.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -30,7 +31,10 @@ public record ProjectDefinition(
         Integer javaVersion,
         Boolean noCode,
         Boolean noExamples,
-        Set<String> extensions) {
+        Boolean noWrapper,
+        Boolean noDockerfiles,
+        Set<String> extensions,
+        Map<String, String> codestartData) {
 
     public ProjectDefinition {
         Objects.requireNonNull(groupId, "groupId is required");
@@ -39,7 +43,10 @@ public record ProjectDefinition(
         Objects.requireNonNull(buildTool, "buildTool is required");
         Objects.requireNonNull(noCode, "noCode is required");
         Objects.requireNonNull(noExamples, "noExamples is required");
+        Objects.requireNonNull(noWrapper, "noWrapper is required");
+        Objects.requireNonNull(noDockerfiles, "noDockerfiles is required");
         Objects.requireNonNull(extensions, "extensions is required");
+        Objects.requireNonNull(codestartData, "codestartData is required");
     }
 
     public static final String DEFAULT_GROUPID = "org.acme";
@@ -48,6 +55,10 @@ public record ProjectDefinition(
     public static final String DEFAULT_BUILDTOOL = "MAVEN";
     public static final Boolean DEFAULT_NO_CODE = false;
     public static final String DEFAULT_NO_CODE_STRING = "false";
+    public static final Boolean DEFAULT_NO_WRAPPER = false;
+    public static final String DEFAULT_NO_WRAPPER_STRING = "false";
+    public static final Boolean DEFAULT_NO_DOCKERFILES = false;
+    public static final String DEFAULT_NO_DOCKERFILES_STRING = "false";
 
     public static final String GROUPID_PATTERN = "^([a-zA-Z_$][a-zA-Z\\d_$]*\\.)*[a-zA-Z_$][a-zA-Z\\d_$]*$";
     public static final String ARTIFACTID_PATTERN = "^[a-z][a-z0-9-._]*$";
@@ -57,7 +68,7 @@ public record ProjectDefinition(
 
     public static ProjectDefinition of() {
         return new ProjectDefinition(null, DEFAULT_GROUPID, DEFAULT_ARTIFACTID, DEFAULT_VERSION, null, null, DEFAULT_BUILDTOOL,
-                null, DEFAULT_NO_CODE, DEFAULT_NO_CODE, Set.of());
+                null, DEFAULT_NO_CODE, DEFAULT_NO_CODE, DEFAULT_NO_WRAPPER, DEFAULT_NO_DOCKERFILES, Set.of(), Map.of());
     }
 
     @JsonCreator
@@ -77,7 +88,10 @@ public record ProjectDefinition(
         private Integer javaVersion = null;
         private Boolean noCode = DEFAULT_NO_CODE;
         private Boolean noExamples = DEFAULT_NO_CODE;
+        private Boolean noWrapper = DEFAULT_NO_WRAPPER;
+        private Boolean noDockerfiles = DEFAULT_NO_DOCKERFILES;
         private Set<String> extensions = Set.of();
+        private Map<String, String> codestartData = Map.of();
 
         private Builder() {
         }
@@ -132,14 +146,29 @@ public record ProjectDefinition(
             return this;
         }
 
+        public Builder noWrapper(Boolean noWrapper) {
+            this.noWrapper = noWrapper;
+            return this;
+        }
+
+        public Builder noDockerfiles(Boolean noDockerfiles) {
+            this.noDockerfiles = noDockerfiles;
+            return this;
+        }
+
         public Builder extensions(Set<String> extensions) {
             this.extensions = extensions;
             return this;
         }
 
+        public Builder codestartData(Map<String, String> codestartData) {
+            this.codestartData = codestartData;
+            return this;
+        }
+
         public ProjectDefinition build() {
             return new ProjectDefinition(streamKey, groupId, artifactId, version, className, path, buildTool, javaVersion,
-                    noCode, noExamples, extensions);
+                    noCode, noExamples, noWrapper, noDockerfiles, extensions, codestartData);
         }
     }
 

--- a/base/src/main/java/io/quarkus/code/model/ProjectDefinitionQuery.java
+++ b/base/src/main/java/io/quarkus/code/model/ProjectDefinitionQuery.java
@@ -8,6 +8,8 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.QueryParam;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import static io.quarkus.code.model.ProjectDefinition.*;
@@ -82,10 +84,38 @@ public class ProjectDefinitionQuery {
     @Schema(description = "The Java version for the generation application", required = false)
     Integer javaVersion;
 
+    @DefaultValue(DEFAULT_NO_WRAPPER_STRING)
+    @QueryParam("nw")
+    @Parameter(name = "nw", description = "No build tool wrapper", required = false)
+    @Schema(description = "No build tool wrapper", required = false, defaultValue = DEFAULT_NO_WRAPPER_STRING)
+    boolean noWrapper = DEFAULT_NO_WRAPPER;
+
+    @DefaultValue(DEFAULT_NO_DOCKERFILES_STRING)
+    @QueryParam("ndf")
+    @Parameter(name = "ndf", description = "No Dockerfiles", required = false)
+    @Schema(description = "No Dockerfiles", required = false, defaultValue = DEFAULT_NO_DOCKERFILES_STRING)
+    boolean noDockerfiles = DEFAULT_NO_DOCKERFILES;
+
     @QueryParam("e")
     @Parameter(name = "e", description = "The set of extension ids that will be included in the generated application", required = false)
     @Schema(description = "The set of extension ids that will be included in the generated application", required = false)
     Set<String> extensions = Set.of();
+
+    @QueryParam("cd")
+    @Parameter(name = "cd", description = "Codestart data (key=value format, e.g. cd=my.key=myvalue)", required = false)
+    @Schema(description = "Codestart data (key=value format, e.g. cd=my.key=myvalue)", required = false)
+    Set<String> codestartData = Set.of();
+
+    static Map<String, String> parseCodestartData(Set<String> entries) {
+        Map<String, String> dataMap = new LinkedHashMap<>();
+        for (String entry : entries) {
+            int idx = entry.indexOf('=');
+            if (idx > 0) {
+                dataMap.put(entry.substring(0, idx), entry.substring(idx + 1));
+            }
+        }
+        return dataMap;
+    }
 
     public ProjectDefinition toProjectDefinition() {
         return new ProjectDefinition(
@@ -99,7 +129,10 @@ public class ProjectDefinitionQuery {
                 javaVersion,
                 noCode,
                 noExamples,
-                extensions);
+                noWrapper,
+                noDockerfiles,
+                extensions,
+                parseCodestartData(codestartData));
     }
 
 }

--- a/base/src/main/java/io/quarkus/code/rest/CodeQuarkusResource.java
+++ b/base/src/main/java/io/quarkus/code/rest/CodeQuarkusResource.java
@@ -253,8 +253,18 @@ public class CodeQuarkusResource {
                     || projectDefinition.noExamples() != ProjectDefinition.DEFAULT_NO_CODE) {
                 params.add(new BasicNameValuePair("nc", String.valueOf(!ProjectDefinition.DEFAULT_NO_CODE)));
             }
+            if (projectDefinition.noWrapper() != ProjectDefinition.DEFAULT_NO_WRAPPER) {
+                params.add(new BasicNameValuePair("nw", String.valueOf(projectDefinition.noWrapper())));
+            }
+            if (projectDefinition.noDockerfiles() != ProjectDefinition.DEFAULT_NO_DOCKERFILES) {
+                params.add(new BasicNameValuePair("ndf", String.valueOf(projectDefinition.noDockerfiles())));
+            }
             if (!projectDefinition.extensions().isEmpty()) {
                 projectDefinition.extensions().forEach(extension -> params.add(new BasicNameValuePair("e", extension)));
+            }
+            if (!projectDefinition.codestartData().isEmpty()) {
+                projectDefinition.codestartData()
+                        .forEach((k, v) -> params.add(new BasicNameValuePair("cd", k + "=" + v)));
             }
             if (projectDefinition.path() != null) {
                 params.add(new BasicNameValuePair("p", projectDefinition.path()));

--- a/base/src/main/java/io/quarkus/code/service/QuarkusProjectService.java
+++ b/base/src/main/java/io/quarkus/code/service/QuarkusProjectService.java
@@ -108,7 +108,13 @@ public class QuarkusProjectService {
                     .javaVersion(javaVersion.getVersion())
                     .resourceClassName(projectDefinition.className())
                     .extensions(extensions)
-                    .noCode(projectDefinition.noCode() || projectDefinition.noExamples());
+                    .noCode(projectDefinition.noCode() || projectDefinition.noExamples())
+                    .noBuildToolWrapper(projectDefinition.noWrapper())
+                    .noDockerfiles(projectDefinition.noDockerfiles());
+            if (!projectDefinition.codestartData().isEmpty()) {
+                projectDefinitionCreateProject.setValue(
+                        CreateProject.CreateProjectKey.DATA, projectDefinition.codestartData());
+            }
             if (platformInfo.quarkusCoreVersion().contains("-redhat-")) {
                 // Hack to use the community quarkus gradle plugin (it is not released with the RHBQ)
                 projectDefinitionCreateProject

--- a/base/src/test/java/io/quarkus/code/model/ProjectDefinitionQueryTest.java
+++ b/base/src/test/java/io/quarkus/code/model/ProjectDefinitionQueryTest.java
@@ -1,0 +1,48 @@
+package io.quarkus.code.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ProjectDefinitionQueryTest {
+
+    @Test
+    public void testParseCodestartDataSimple() {
+        Map<String, String> result = ProjectDefinitionQuery.parseCodestartData(Set.of("key=value"));
+        assertEquals(Map.of("key", "value"), result);
+    }
+
+    @Test
+    public void testParseCodestartDataDottedKey() {
+        Map<String, String> result = ProjectDefinitionQuery.parseCodestartData(Set.of("my.nested.key=myvalue"));
+        assertEquals(Map.of("my.nested.key", "myvalue"), result);
+    }
+
+    @Test
+    public void testParseCodestartDataValueWithEquals() {
+        Map<String, String> result = ProjectDefinitionQuery.parseCodestartData(Set.of("key=val=ue"));
+        assertEquals(Map.of("key", "val=ue"), result);
+    }
+
+    @Test
+    public void testParseCodestartDataMultipleEntries() {
+        Map<String, String> result = ProjectDefinitionQuery.parseCodestartData(Set.of("a=1", "b.c=2"));
+        assertEquals(Map.of("a", "1", "b.c", "2"), result);
+    }
+
+    @Test
+    public void testParseCodestartDataEmpty() {
+        Map<String, String> result = ProjectDefinitionQuery.parseCodestartData(Set.of());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testParseCodestartDataInvalidEntriesIgnored() {
+        Map<String, String> result = ProjectDefinitionQuery.parseCodestartData(Set.of("noequals", "=nokey", "valid=entry"));
+        assertEquals(Map.of("valid", "entry"), result);
+    }
+}

--- a/base/src/test/java/io/quarkus/code/service/QuarkusProjectServiceTest.java
+++ b/base/src/test/java/io/quarkus/code/service/QuarkusProjectServiceTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -294,6 +295,45 @@ public class QuarkusProjectServiceTest {
                         "src/main/webui/package.json",
                         "src/main/java/my/quinoa/yaml/app/GreetingConfig.java",
                         "src/main/resources/application.yml");
+    }
+
+    @Test
+    @DisplayName("When noWrapper is true, then, the project should not contain Maven wrapper files")
+    void testNoWrapper(TestInfo info) throws Throwable {
+        QuarkusProjectService creator = getProjectService();
+        Path projDir = creator.createTmp(platformService.recommendedPlatformInfo(),
+                ProjectDefinition.builder().noWrapper(true).build());
+
+        assertThat(projDir.resolve("mvnw")).doesNotExist();
+        assertThat(projDir.resolve("mvnw.cmd")).doesNotExist();
+        assertThat(projDir.resolve(".mvn")).doesNotExist();
+    }
+
+    @Test
+    @DisplayName("When noDockerfiles is true, then, the project should not contain Dockerfiles")
+    void testNoDockerfiles(TestInfo info) throws Throwable {
+        QuarkusProjectService creator = getProjectService();
+        Path projDir = creator.createTmp(platformService.recommendedPlatformInfo(),
+                ProjectDefinition.builder().noDockerfiles(true).build());
+
+        assertThat(projDir.resolve("src/main/docker")).doesNotExist();
+    }
+
+    @Test
+    @DisplayName("When using codestart data with rest-codestart keys, then, it should set resource class name and path")
+    void testCodestartData(TestInfo info) throws Throwable {
+        QuarkusProjectService creator = getProjectService();
+        Path projDir = creator.createTmp(platformService.recommendedPlatformInfo(),
+                ProjectDefinition.builder()
+                        .codestartData(Map.of(
+                                "rest-codestart.resource.class-name", "MyCustomResource",
+                                "rest-codestart.resource.path", "/custom"))
+                        .build());
+
+        assertThat(projDir.resolve("src/main/java/org/acme/MyCustomResource.java")).exists();
+        assertThatMatchSnapshot(info, projDir, "src/main/java/org/acme/MyCustomResource.java")
+                .satisfies(checkContains("@Path(\"/custom\")"))
+                .satisfies(checkContains("class MyCustomResource"));
     }
 
     @Test

--- a/base/src/test/resources/__snapshots__/QuarkusProjectServiceTest/testCodestartData/src_main_java_org_acme_MyCustomResource.java
+++ b/base/src/test/resources/__snapshots__/QuarkusProjectServiceTest/testCodestartData/src_main_java_org_acme_MyCustomResource.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/custom")
+public class MyCustomResource {
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello() {
+        return "Hello from Quarkus REST";
+    }
+}


### PR DESCRIPTION
## Summary
- Add `nw` (no wrapper), `ndf` (no dockerfiles), and `cd` (codestart data) query params to the download/generate API
- These pass through to Quarkus DevTools `CreateProject` via `.noBuildToolWrapper()`, `.noDockerfiles()`, and `setValue(DATA, ...)`
- Codestart data supports arbitrary `key=value` entries (e.g. `cd=rest-codestart.resource.class-name=MyResource`)
- Also adds CLAUDE.md to .gitignore