### PR TITLE
Add extraCodestarts param and exclude cd/ec from shareable URLs

### DIFF
--- a/base/src/main/java/io/quarkus/code/model/ProjectDefinition.java
+++ b/base/src/main/java/io/quarkus/code/model/ProjectDefinition.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -34,6 +35,7 @@ public record ProjectDefinition(
         Boolean noWrapper,
         Boolean noDockerfiles,
         Set<String> extensions,
+        List<String> extraCodestarts,
         Map<String, String> codestartData) {
 
     public ProjectDefinition {
@@ -46,6 +48,7 @@ public record ProjectDefinition(
         Objects.requireNonNull(noWrapper, "noWrapper is required");
         Objects.requireNonNull(noDockerfiles, "noDockerfiles is required");
         Objects.requireNonNull(extensions, "extensions is required");
+        Objects.requireNonNull(extraCodestarts, "extraCodestarts is required");
         Objects.requireNonNull(codestartData, "codestartData is required");
     }
 
@@ -68,7 +71,8 @@ public record ProjectDefinition(
 
     public static ProjectDefinition of() {
         return new ProjectDefinition(null, DEFAULT_GROUPID, DEFAULT_ARTIFACTID, DEFAULT_VERSION, null, null, DEFAULT_BUILDTOOL,
-                null, DEFAULT_NO_CODE, DEFAULT_NO_CODE, DEFAULT_NO_WRAPPER, DEFAULT_NO_DOCKERFILES, Set.of(), Map.of());
+                null, DEFAULT_NO_CODE, DEFAULT_NO_CODE, DEFAULT_NO_WRAPPER, DEFAULT_NO_DOCKERFILES, Set.of(), List.of(),
+                Map.of());
     }
 
     @JsonCreator
@@ -91,6 +95,7 @@ public record ProjectDefinition(
         private Boolean noWrapper = DEFAULT_NO_WRAPPER;
         private Boolean noDockerfiles = DEFAULT_NO_DOCKERFILES;
         private Set<String> extensions = Set.of();
+        private List<String> extraCodestarts = List.of();
         private Map<String, String> codestartData = Map.of();
 
         private Builder() {
@@ -161,6 +166,11 @@ public record ProjectDefinition(
             return this;
         }
 
+        public Builder extraCodestarts(List<String> extraCodestarts) {
+            this.extraCodestarts = extraCodestarts;
+            return this;
+        }
+
         public Builder codestartData(Map<String, String> codestartData) {
             this.codestartData = codestartData;
             return this;
@@ -168,7 +178,7 @@ public record ProjectDefinition(
 
         public ProjectDefinition build() {
             return new ProjectDefinition(streamKey, groupId, artifactId, version, className, path, buildTool, javaVersion,
-                    noCode, noExamples, noWrapper, noDockerfiles, extensions, codestartData);
+                    noCode, noExamples, noWrapper, noDockerfiles, extensions, extraCodestarts, codestartData);
         }
     }
 

--- a/base/src/main/java/io/quarkus/code/model/ProjectDefinitionQuery.java
+++ b/base/src/main/java/io/quarkus/code/model/ProjectDefinitionQuery.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.QueryParam;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -101,6 +102,11 @@ public class ProjectDefinitionQuery {
     @Schema(description = "The set of extension ids that will be included in the generated application", required = false)
     Set<String> extensions = Set.of();
 
+    @QueryParam("ec")
+    @Parameter(name = "ec", description = "Extra codestarts to include in the generated application", required = false)
+    @Schema(description = "Extra codestarts to include in the generated application", required = false)
+    List<String> extraCodestarts = List.of();
+
     @QueryParam("cd")
     @Parameter(name = "cd", description = "Codestart data (key=value format, e.g. cd=my.key=myvalue)", required = false)
     @Schema(description = "Codestart data (key=value format, e.g. cd=my.key=myvalue)", required = false)
@@ -132,6 +138,7 @@ public class ProjectDefinitionQuery {
                 noWrapper,
                 noDockerfiles,
                 extensions,
+                extraCodestarts,
                 parseCodestartData(codestartData));
     }
 

--- a/base/src/main/java/io/quarkus/code/rest/CodeQuarkusResource.java
+++ b/base/src/main/java/io/quarkus/code/rest/CodeQuarkusResource.java
@@ -262,10 +262,6 @@ public class CodeQuarkusResource {
             if (!projectDefinition.extensions().isEmpty()) {
                 projectDefinition.extensions().forEach(extension -> params.add(new BasicNameValuePair("e", extension)));
             }
-            if (!projectDefinition.codestartData().isEmpty()) {
-                projectDefinition.codestartData()
-                        .forEach((k, v) -> params.add(new BasicNameValuePair("cd", k + "=" + v)));
-            }
             if (projectDefinition.path() != null) {
                 params.add(new BasicNameValuePair("p", projectDefinition.path()));
             }

--- a/base/src/main/java/io/quarkus/code/service/QuarkusProjectService.java
+++ b/base/src/main/java/io/quarkus/code/service/QuarkusProjectService.java
@@ -79,6 +79,7 @@ public class QuarkusProjectService {
         if (gitHub) {
             codestarts.add("tooling-github-action");
         }
+        codestarts.addAll(projectDefinition.extraCodestarts());
         JavaVersion javaVersion = new JavaVersion(javaVersionString);
         if (javaVersion.isPresent() && !platformInfo.stream().javaCompatibility().versions().contains(javaVersion.getAsInt())) {
             throw new IllegalArgumentException("This Java version is not compatible with this stream ("


### PR DESCRIPTION
## Summary
- Add `ec` query param for extra codestarts to include in project generation
- Remove `cd` (codestart data) and `ec` from shareable `/d?...` URLs to prevent injecting unexpected code via crafted links