### PR TITLE
Remove redundant @Blocking from StartupEvent observer

### DIFF
--- a/base/src/main/java/io/quarkus/code/service/PlatformService.java
+++ b/base/src/main/java/io/quarkus/code/service/PlatformService.java
@@ -29,7 +29,6 @@ import io.quarkus.registry.Constants;
 import io.quarkus.registry.ExtensionCatalogResolver;
 import io.quarkus.registry.catalog.PlatformRelease;
 import io.quarkus.runtime.LaunchMode;
-import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -109,7 +108,6 @@ public class PlatformService {
     private final ExtensionCatalogResolver catalogResolver;
     private final AtomicReference<PlatformServiceCache> platformServiceCacheRef = new AtomicReference<>();
 
-    @Blocking
     public void onStart(@Observes StartupEvent e) {
         reload();
     }


### PR DESCRIPTION
## Summary
- Remove `@Blocking` annotation from `PlatformService.onStart()` 
- Quarkus main added `ExecutionModelAnnotationsProcessor#check` which rejects `@Blocking` on non-entrypoint methods
- `@Observes StartupEvent` observers already run on a blocking thread, so the annotation was redundant
- Fixes ecosystem CI failure: https://github.com/quarkusio/code.quarkus.io/actions/runs/27111601257