### PR TITLE
feat: Additional entreprise support links

### DIFF
--- a/base/src/main/resources/web/lib/components/header/code-quarkus-io-header.scss
+++ b/base/src/main/resources/web/lib/components/header/code-quarkus-io-header.scss
@@ -49,6 +49,26 @@
           color: #D73F22;
         }
 
+        .icon-ibm {
+          margin-right: 20px;
+          width: 1em;
+          height: 1em;
+          vertical-align: middle;
+          filter: brightness(0) saturate(100%) invert(27%) sepia(83%) saturate(5765%) hue-rotate(220deg) brightness(101%) contrast(99%);
+        }
+
+        .icon-text-ibm {
+          margin-right: 20px;
+          align-items: center;
+          justify-content: center;
+          width: 1em;
+          height: 1em;
+          font-size: 1em;
+          font-weight: bold;
+          vertical-align: middle;
+          color: #0f62fe;
+        }
+
         &:hover {
           text-decoration: none;
           border-color: var(--headerSupportPanelTextColor);
@@ -61,7 +81,7 @@
       }
 
       .support-panel {
-        max-height: 100px;
+        max-height: 200px;
       }
     }
 

--- a/base/src/main/resources/web/lib/components/header/code-quarkus-io-header.tsx
+++ b/base/src/main/resources/web/lib/components/header/code-quarkus-io-header.tsx
@@ -23,6 +23,8 @@ function SupportButton(prop: {}) {
       <Button onClick={openPanel} aria-label="enterprise support"><FaHandsHelping/> Available with Enterprise Support</Button>
       <div className="support-panel">
         <a href="https://code.quarkus.redhat.com" onClick={linkTracker}><FaRedhat />Code with the Red Hat Build of Quarkus</a>
+        <a href="https://code.camel.redhat.com/" onClick={linkTracker}><FaRedhat />Code with the Red Hat Build of Apache Camel</a>
+        <a href="https://code.quarkus.ibm.com" onClick={linkTracker}><img className="icon-ibm" src="https://www.ibm.com/content/dam/adobe-cms/default-images/favicon.svg" alt="IBM" onError={(e) => { e.currentTarget.style.display = 'none'; (e.currentTarget.nextElementSibling as HTMLElement).style.display = 'inline-flex'; }} /><span className="icon-text-ibm" style={{display: 'none'}}>IBM</span>Code with the IBM Enterprise Build of Quarkus</a>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes  #1645 

Use a text icon placeholder for IBM as there is not official icon either on the target website: https://code.quarkus.ibm.com/.

<img width="616" height="168" alt="Capture d’écran du 2026-06-23 16-26-42" src="https://github.com/user-attachments/assets/fad0868a-b61b-46d7-9947-668b44d2852a" />

Fallback to (don't mind the different sizes, it's my browser style):
<img width="537" height="158" alt="Capture d’écran du 2026-06-23 16-04-36" src="https://github.com/user-attachments/assets/5dc9f2db-b93c-481f-bafe-7c0fc3667bcb" />



