### PR TITLE
feat: Add integrates metadatas

### DIFF
--- a/base/src/main/java/io/quarkus/code/misc/QuarkusExtensionUtils.java
+++ b/base/src/main/java/io/quarkus/code/misc/QuarkusExtensionUtils.java
@@ -1,6 +1,7 @@
 package io.quarkus.code.misc;
 
 import io.quarkus.code.model.CodeQuarkusExtension;
+import io.quarkus.code.model.IntegratedDependency;
 import io.quarkus.code.service.PlatformOverride;
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.platform.catalog.processor.CatalogProcessor;
@@ -12,8 +13,8 @@ import io.quarkus.registry.catalog.ExtensionCatalog;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 public class QuarkusExtensionUtils {
 
@@ -69,7 +70,24 @@ public class QuarkusExtensionUtils {
                 .guide(extensionProcessor.getGuide())
                 .platform(ext.hasPlatformOrigin())
                 .bom("%s:%s:%s".formatted(bom.getGroupId(), bom.getArtifactId(), bom.getVersion()))
+                .integrates(getIntegrates(ext))
                 .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<IntegratedDependency> getIntegrates(Extension ext) {
+        Object raw = ext.getMetadata().get("integrates");
+        if (!(raw instanceof List<?> list) || list.isEmpty()) {
+            return null;
+        }
+        return list.stream()
+                .filter(Map.class::isInstance)
+                .map(e -> (Map<String, Object>) e)
+                .map(m -> new IntegratedDependency(
+                        (String) m.get("name"),
+                        (String) m.get("artifact"),
+                        (String) m.get("version")))
+                .toList();
     }
 
     private static List<String> getTags(ExtensionProcessor extension) {

--- a/base/src/main/java/io/quarkus/code/model/CodeQuarkusExtension.java
+++ b/base/src/main/java/io/quarkus/code/model/CodeQuarkusExtension.java
@@ -18,6 +18,7 @@ public record CodeQuarkusExtension(
         List<String> transitiveExtensions,
         List<String> tags,
         Set<String> keywords,
+        List<IntegratedDependency> integrates,
         @Deprecated boolean providesExampleCode,
         boolean providesCode,
         String guide,
@@ -51,7 +52,8 @@ public record CodeQuarkusExtension(
                 .guide(existing.guide())
                 .order(existing.order())
                 .platform(existing.platform())
-                .bom(existing.bom());
+                .bom(existing.bom())
+                .integrates(existing.integrates());
     }
 
     public static class Builder {
@@ -71,6 +73,7 @@ public record CodeQuarkusExtension(
         private int order;
         private boolean platform;
         private String bom;
+        private List<IntegratedDependency> integrates;
 
         private Builder() {
         }
@@ -155,6 +158,11 @@ public record CodeQuarkusExtension(
             return this;
         }
 
+        public Builder integrates(List<IntegratedDependency> integrates) {
+            this.integrates = integrates;
+            return this;
+        }
+
         public CodeQuarkusExtension build() {
             return new CodeQuarkusExtension(
                     id,
@@ -167,6 +175,7 @@ public record CodeQuarkusExtension(
                     transitiveExtensions,
                     tags,
                     keywords,
+                    integrates,
                     providesExampleCode,
                     providesCode,
                     guide,

--- a/base/src/main/java/io/quarkus/code/model/IntegratedDependency.java
+++ b/base/src/main/java/io/quarkus/code/model/IntegratedDependency.java
@@ -1,0 +1,8 @@
+package io.quarkus.code.model;
+
+public record IntegratedDependency(
+        String name,
+        String artifact,
+        String version) {
+
+}

--- a/base/src/main/resources/web/lib/components/api/model.ts
+++ b/base/src/main/resources/web/lib/components/api/model.ts
@@ -35,6 +35,7 @@ export interface Extension {
   keywords: string[];
   transitiveExtensions: string[];
   tags: string[];
+  integrates?: { name: string; artifact: string; version: string }[];
   description?: string;
   shortName?: string;
   category: string;

--- a/base/src/test/java/io/quarkus/code/misc/QuarkusExtensionUtilsTest.java
+++ b/base/src/test/java/io/quarkus/code/misc/QuarkusExtensionUtilsTest.java
@@ -1,6 +1,7 @@
 package io.quarkus.code.misc;
 
 import io.quarkus.code.model.CodeQuarkusExtension;
+import io.quarkus.code.model.IntegratedDependency;
 import io.quarkus.code.service.PlatformOverride;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,8 @@ import static io.quarkus.code.misc.QuarkusExtensionUtils.toShortcut;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
 
 class QuarkusExtensionUtilsTest {
     private static final String FAKE_CATALOG_JSON = "/fakeextensions.json";
@@ -78,6 +81,26 @@ class QuarkusExtensionUtilsTest {
                         "RESTEasy JSON-B",
                         "Eclipse Vert.x GraphQL",
                         "gRPC"));
+    }
+
+    @Test
+    void testIntegrates() throws IOException {
+        List<CodeQuarkusExtension> extensions = processExtensions(getTestCatalog(), PlatformOverride.DEFAULT_PLATFORM_OVERRIDE);
+
+        CodeQuarkusExtension camelCore = extensions.stream()
+                .filter(e -> e.id().equals("org.apache.camel.quarkus:camel-quarkus-core"))
+                .findFirst()
+                .orElse(null);
+        assertThat(camelCore, is(notNullValue()));
+        assertThat(camelCore.integrates(), is(List.of(
+                new IntegratedDependency("Camel", "org.apache.camel:camel-core", "4.10.0"))));
+
+        CodeQuarkusExtension resteasy = extensions.stream()
+                .filter(e -> e.id().equals("io.quarkus:quarkus-resteasy"))
+                .findFirst()
+                .orElse(null);
+        assertThat(resteasy, is(notNullValue()));
+        assertThat(resteasy.integrates(), is(nullValue()));
     }
 
     private ExtensionCatalog getTestCatalog() throws IOException {

--- a/base/src/test/resources/fakeextensions.json
+++ b/base/src/test/resources/fakeextensions.json
@@ -2254,6 +2254,22 @@
     },
     "artifact" : "io.quarkus:quarkus-redis-client::jar:5.5.0.1",
     "origins" : [ "io.quarkus:quarkus-bom-quarkus-platform-descriptor:5.5.0.1:json:5.5.0.1" ]
+  }, {
+    "name" : "Camel Core",
+    "description" : "Apache Camel integration framework",
+    "metadata" : {
+      "keywords" : [ "camel", "integration" ],
+      "categories" : [ "integration" ],
+      "status" : "stable",
+      "built-with-quarkus-core" : "5.5.0.1",
+      "integrates" : [ {
+        "name" : "Camel",
+        "artifact" : "org.apache.camel:camel-core",
+        "version" : "4.10.0"
+      } ]
+    },
+    "artifact" : "org.apache.camel.quarkus:camel-quarkus-core::jar:3.20.0",
+    "origins" : [ "io.quarkus:quarkus-bom-quarkus-platform-descriptor:5.5.0.1:json:5.5.0.1" ]
   } ],
   "categories" : [ {
     "id" : "web",
@@ -2328,6 +2344,11 @@
     "id" : "alt-languages",
     "name" : "Alternative languages",
     "description" : "Support for other JVM based languages",
+    "metadata" : { }
+  }, {
+    "id" : "integration",
+    "name" : "Integration",
+    "description" : "Integration frameworks",
     "metadata" : { }
   } ],
   "metadata" : {


### PR DESCRIPTION
Propagate new metadata `integrates` (see https://github.com/quarkusio/quarkus/issues/35404#issuecomment-4119152668) to make it available on frontend.

Will be used here: https://github.com/redhat-developer/code.quarkus.redhat.com/pull/262