### PR TITLE
Use category name as label and id as query parameter

### DIFF
--- a/base/src/main/java/io/quarkus/code/misc/QuarkusExtensionUtils.java
+++ b/base/src/main/java/io/quarkus/code/misc/QuarkusExtensionUtils.java
@@ -1,5 +1,6 @@
 package io.quarkus.code.misc;
 
+import io.quarkus.code.model.CodeQuarkusCategory;
 import io.quarkus.code.model.CodeQuarkusExtension;
 import io.quarkus.code.service.PlatformOverride;
 import io.quarkus.maven.dependency.ArtifactCoords;
@@ -59,7 +60,7 @@ public class QuarkusExtensionUtils {
                 .name(ext.getName())
                 .description(ext.getDescription())
                 .shortName(extensionProcessor.getShortName())
-                .category(cat.getName())
+                .category(new CodeQuarkusCategory(cat.getId(), cat.getName()))
                 .tags(platformOverride.extensionTagsMapper(getTags(extensionProcessor)))
                 .keywords(extensionProcessor.getExtendedKeywords())
                 .transitiveExtensions(ExtensionProcessor.getMetadataValue(ext, "extension-dependencies").asStringList())

--- a/base/src/main/java/io/quarkus/code/model/CodeQuarkusCategory.java
+++ b/base/src/main/java/io/quarkus/code/model/CodeQuarkusCategory.java
@@ -1,0 +1,9 @@
+package io.quarkus.code.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CodeQuarkusCategory(
+        String id,
+        String name) {
+}

--- a/base/src/main/java/io/quarkus/code/model/CodeQuarkusExtension.java
+++ b/base/src/main/java/io/quarkus/code/model/CodeQuarkusExtension.java
@@ -14,7 +14,7 @@ public record CodeQuarkusExtension(
         String name,
         String description,
         String shortName,
-        String category,
+        CodeQuarkusCategory category,
         List<String> transitiveExtensions,
         List<String> tags,
         Set<String> keywords,
@@ -61,7 +61,7 @@ public record CodeQuarkusExtension(
         private String name;
         private String description;
         private String shortName = "";
-        private String category;
+        private CodeQuarkusCategory category;
         private List<String> tags;
         private List<String> transitiveExtensions = List.of();
         private Set<String> keywords;
@@ -105,7 +105,7 @@ public record CodeQuarkusExtension(
             return this;
         }
 
-        public Builder category(String category) {
+        public Builder category(CodeQuarkusCategory category) {
             this.category = category;
             return this;
         }

--- a/base/src/main/resources/web/lib/components/api/model.ts
+++ b/base/src/main/resources/web/lib/components/api/model.ts
@@ -37,7 +37,7 @@ export interface Extension {
   tags: string[];
   description?: string;
   shortName?: string;
-  category: string;
+  category: Category;
   platform: boolean;
   default: boolean;
   order: number;
@@ -70,6 +70,11 @@ export interface Platform {
 export interface JavaCompatibility {
   versions: number[];
   recommended: number;
+}
+
+export interface Category {
+    id: string;
+    name: string;
 }
 
 export interface BuildToolCompatibility {

--- a/base/src/main/resources/web/lib/components/extensions-picker/extensions-picker.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extensions-picker.tsx
@@ -3,7 +3,7 @@ import {useHotkeys} from 'react-hotkeys-hook';
 import {useAnalytics} from '../../core/analytics';
 import {InputProps} from '../../core/types';
 import {debouncedComputeResults, FilterResult, ProcessedExtensions, processExtensionsValues} from './extensions-utils';
-import {Platform, QuarkusProject} from '../api/model';
+import {Category, Platform, QuarkusProject} from '../api/model';
 import './extensions-picker.scss';
 import {ExtensionRow} from './extension-row';
 import {ExtensionSearchBar} from './extension-search-bar';
@@ -24,7 +24,7 @@ export interface ExtensionEntry {
   tags: string[];
   description?: string;
   shortName?: string;
-  category: string;
+  category: Category;
   order: number;
   default: boolean;
   guide?: string;
@@ -153,7 +153,7 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
     }
   }, hotkeysOptions, [entries, keyboardIndex]);
 
-  let currentCat: string | undefined;
+  let currentCat: Category | undefined;
 
   function toggleShowList() {
     setKeyboardIndex(-1);
@@ -209,12 +209,12 @@ export const ExtensionsPicker = (props: ExtensionsPickerProps) => {
                     layout="picker"
                   />
                 );
-                if (!result.filtered && (!currentCat || currentCat !== ex.category)) {
+                if (!result.filtered && (!currentCat || currentCat.id !== ex.category.id)) {
                   currentCat = ex.category;
                   return (
                     <React.Fragment key={i}>
                       <div className="extension-category">
-                        {currentCat}
+                        {currentCat.name}
                       </div>
                       {ext}
                     </React.Fragment>

--- a/base/src/main/resources/web/lib/components/extensions-picker/extensions-utils.ts
+++ b/base/src/main/resources/web/lib/components/extensions-picker/extensions-utils.ts
@@ -1,8 +1,8 @@
 import {ExtensionEntry} from './extensions-picker';
-import {Extension} from '../api/model';
+import {Category, Extension} from '../api/model';
 import _ from 'lodash';
 import {Analytics} from '../../core/analytics';
-import {parse, EqFilter, InFilter, TermFilter, Filter} from "../../core/search";
+import {EqFilter, Filter, InFilter, parse, TermFilter} from "../../core/search";
 
 type ExtensionFieldValueSupplier = (e: Extension) => string | string[] | undefined
 
@@ -25,7 +25,7 @@ const FIELD_IDENTIFIERS: ExtensionFieldIdentifier[] = [
   {keys: ['keywords', 'keyword'], valueSupplier: e => e.keywords},
   {keys: ['tags', 'tag'], valueSupplier: e => e.tags},
   {keys: ['platform', 'p'], valueSupplier: e => e.platform ? 'yes' : 'no'},
-  {keys: ['category', 'cat'], valueSupplier: e => catToId(e.category)},
+  {keys: ['category', 'cat'], valueSupplier: e => e.category?.id},
 ];
 
 const FIELD_KEYS = FIELD_IDENTIFIERS.map(s => s.keys).reduce((acc, value) => acc.concat(value), [])
@@ -53,8 +53,8 @@ export function getAllKeys(extensions: Extension[]): string[] {
   return Array.from(keys);
 }
 
-export function processTags(tags: string[]): { [field: string]: string[] } {
-  const processed: { [field: string]: string[] } = {};
+export function processTags(tags: string[]): { [field: string]: FilterOption[] } {
+  const processed: { [field: string]: FilterOption[] } = {};
   for (let tag of tags) {
     let key: string, value: string;
     if (tag.indexOf(':') > 0) {
@@ -71,7 +71,7 @@ export function processTags(tags: string[]): { [field: string]: string[] } {
     if (!processed[key]) {
       processed[key] = [];
     }
-    processed[key].push(value);
+    processed[key].push({value: value, label: value});
   }
   return processed;
 }
@@ -214,6 +214,11 @@ export const removeDuplicateIds = (entries: ExtensionEntry[]): ExtensionEntry[] 
   return _.uniqBy(entries, 'id');
 };
 
+export interface FilterOption{
+    label: string;
+    value: string;
+}
+
 export interface MetadataFilterValues {
   radio: boolean;
   optional: boolean;
@@ -280,25 +285,23 @@ export function addStarMetadataFilter(query: string, key: string) {
 }
 
 
-function catToId(category?: string): string {
-  return category?.toLowerCase().replace(' ', '-').replace(/\s+.+$/i, '');
-}
-
 function getMetadataFilters(filters: Filter[], entries: ExtensionEntry[]): MetadataFilters {
   const tags = new Set<string>();
-  const cats = new Set<string>();
+  const cats = new Map<string, FilterOption>();
   for (let entry of entries) {
     if (entry.tags) {
-      for (let tag of entry.tags) {
-        tags.add(tag);
-      }
+        for (let tag of entry.tags) {
+            tags.add(tag);
+        }
+        // Do a uniqueness check here rather than filtering after, since Sets do uniqueness by reference for objects
+        if (!cats.has(entry.category.id)) {
+            cats.set(entry.category.id, {label: entry.category.name, value: entry.category.id});
+        }
     }
-    cats.add(catToId(entry.category))
   }
   const tagFilters = processTags(Array.from(tags));
-  tagFilters.category = Array.from(cats);
-  tagFilters.platform = ['yes', 'no'];
-
+  tagFilters.category = [...cats.values()];
+  tagFilters.platform = toFilterOptions(['yes', 'no']);
 
   const metadataFilters: MetadataFilters = {};
 
@@ -308,8 +311,9 @@ function getMetadataFilters(filters: Filter[], entries: ExtensionEntry[]): Metad
     let any = filterForTag?.values?.includes('*') && !filterForTag.negated;
     let exclude = filterForTag?.values?.includes('*') && filterForTag.negated;
     metadataFilters[key] = {all: [], active: [], inactive: [], any, exclude,  radio: RADIO_FILTER_PREDICATE(key), optional: OPTIONAL_FILTER_PREDICATE(key)};
-    for (let value of tagFilters[key]) {
-      let label = value;
+      for (let entry of tagFilters[key]) {
+      let label = entry.label;
+      let value = entry.value;
       let active = !filterForTag.negated && (filterForTag?.values?.includes(value) || any);
 
       if (active) {
@@ -323,6 +327,10 @@ function getMetadataFilters(filters: Filter[], entries: ExtensionEntry[]): Metad
 
   }
   return metadataFilters;
+}
+
+function toFilterOptions(strings: string[]): FilterOption[] {
+    return strings.map(s => ( {label: s, value: s}));
 }
 
 export function toFilterResult(filters: Filter[], entries: Extension[], filteredEntries: Extension[], filtered: boolean, onResult: (result: FilterResult) => void) {

--- a/base/src/main/resources/web/lib/components/extensions-picker/filter-combo.tsx
+++ b/base/src/main/resources/web/lib/components/extensions-picker/filter-combo.tsx
@@ -53,7 +53,7 @@ export function FilterCombo({
             key={idx}
             className={classNames('filter-option', item.active ? "active" : "inactive")}
             onClick={() => onToggleValue(item.value, item.active)}
-            aria-label={`${item.active ? 'Remove' : 'Add'} ${label}:${item.label} filter`}
+            aria-label={`${item.active ? 'Remove' : 'Add'} ${label}:${item.value} filter`}
           >
             {item.active ? selectIcons[0] : selectIcons[1]}
             <span className='label'>{item.label}</span>

--- a/base/src/test/java/io/quarkus/code/CodeQuarkusPlaywrightTest.java
+++ b/base/src/test/java/io/quarkus/code/CodeQuarkusPlaywrightTest.java
@@ -106,7 +106,7 @@ public class CodeQuarkusPlaywrightTest {
                         .toList();
                 refs.forEach(ref -> {
                     assertThat(platformService.recommendedPlatformInfo().codeQuarkusExtensions()).anyMatch(
-                            e -> e.id().equals(ref.id()) && e.category().equalsIgnoreCase("cloud"));
+                            e -> e.id().equals(ref.id()) && e.category().id().equalsIgnoreCase("cloud"));
                 });
             });
 

--- a/base/src/test/java/io/quarkus/code/misc/QuarkusExtensionUtilsTest.java
+++ b/base/src/test/java/io/quarkus/code/misc/QuarkusExtensionUtilsTest.java
@@ -1,5 +1,6 @@
 package io.quarkus.code.misc;
 
+import io.quarkus.code.model.CodeQuarkusCategory;
 import io.quarkus.code.model.CodeQuarkusExtension;
 import io.quarkus.code.service.PlatformOverride;
 import io.quarkus.registry.catalog.ExtensionCatalog;
@@ -38,7 +39,7 @@ class QuarkusExtensionUtilsTest {
                         .name("RESTEasy JAX-RS")
                         .description("REST endpoint framework implementing JAX-RS and more")
                         .shortName("jax-rs")
-                        .category("Web")
+                        .category(new CodeQuarkusCategory("web", "Webbed"))
                         .tags(List.of("with:starter-code", "status:stable"))
                         .keywords(Set.of("endpoint", "framework", "jax", "jaxrs", "jax-rs", "quarkus-resteasy", "rest",
                                 "resteasy", "web"))
@@ -55,7 +56,7 @@ class QuarkusExtensionUtilsTest {
                 .version("5.5.0.1")
                 .name("Mutiny support for REST Client")
                 .description("Enable Mutiny for the REST client")
-                .category("Web")
+                .category(new CodeQuarkusCategory("web", "Webbed"))
                 .tags(List.of("status:preview"))
                 .keywords(Set.of("rest", "reactive", "web", "web-client", "rest-client", "client", "quarkus-rest-client-mutiny",
                         "microprofile-rest-client", "support", "mutiny", "rest-client-mutiny"))

--- a/base/src/test/java/io/quarkus/code/rest/CodeQuarkusResourceTest.java
+++ b/base/src/test/java/io/quarkus/code/rest/CodeQuarkusResourceTest.java
@@ -100,7 +100,7 @@ class CodeQuarkusResourceTest {
         var projectDefinition = ProjectDefinition.builder().noCode(true)
                 .extensions(platformService.recommendedCodeQuarkusExtensions()
                         .stream()
-                        .filter(extension -> !extension.category().equals("Alternative languages"))
+                        .filter(extension -> !"alt-languages".equals(extension.category().id()))
                         // Remove this when we use java 25 in quarkus
                         .filter(extension -> !"io.quarkiverse.langchain4j:quarkus-langchain4j-gpu-llama3"
                                 .equals(extension.id()))

--- a/base/src/test/resources/fakeextensions.json
+++ b/base/src/test/resources/fakeextensions.json
@@ -2257,7 +2257,7 @@
   } ],
   "categories" : [ {
     "id" : "web",
-    "name" : "Web",
+    "name" : "Webbed",
     "description" : "Everything you need for REST endpoints, HTTP and web formats like JSON",
     "metadata" : {
       "pinned" : [ "io.quarkus:quarkus-resteasy", "io.quarkus:quarkus-resteasy-jackson", "io.quarkus:quarkus-resteasy-jsonb" ]


### PR DESCRIPTION
As requested by @cescoffier.  Resolves https://github.com/quarkusio/code.quarkus.io/issues/1836

The front-end *almost* already had logic for distinct values and labels in the dropdown filters, it just needed a few things stitching together. I've added a new record on the backend and a new interface on the front end, to capture the fact that categories have both a name and an id.

This changes the drop-down to use the extension label, while using the value in the query string. It's a slightly breaking change because some urls, like AI, change, from https://code.quarkus.io/?extension-search=category:artificial-intelligence to http://localhost:8080/?extension-search=category:ai. However, as the url being used is now aligned with the platform categories, I think that's ok.

I had a dilemma about whether to use the name or id in the aria label, now they're distinct. I went for the id, since it's more concise and what the tests expect.

### Before: 

<img width="1168" height="745" alt="image" src="https://github.com/user-attachments/assets/c955b600-bd96-474d-87df-9b2c62916544" />

### After:

<img width="1193" height="489" alt="image" src="https://github.com/user-attachments/assets/be01c6df-1ed1-465d-b327-89bfa2a09860" />
