### PR TITLE
fix: upgrade @sentry/browser to 10.73.0 and handle package renames

### DIFF
--- a/web-deps/locker/pom.xml
+++ b/web-deps/locker/pom.xml
@@ -108,38 +108,48 @@
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.sentry-internal</groupId>
-        <artifactId>feedback</artifactId>
-        <version>10.56.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mvnpm.at.sentry-internal</groupId>
-        <artifactId>replay-canvas</artifactId>
-        <version>10.56.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mvnpm.at.sentry-internal</groupId>
         <artifactId>tracing</artifactId>
         <version>7.114.0</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.sentry</groupId>
         <artifactId>browser</artifactId>
-        <version>10.56.0</version>
+        <version>10.73.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.sentry</groupId>
+        <artifactId>browser-utils</artifactId>
+        <version>10.73.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.sentry</groupId>
+        <artifactId>conventions</artifactId>
+        <version>0.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.sentry</groupId>
         <artifactId>core</artifactId>
-        <version>10.56.0</version>
+        <version>10.73.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.sentry</groupId>
+        <artifactId>feedback</artifactId>
+        <version>10.73.0</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.sentry</groupId>
         <artifactId>replay</artifactId>
-        <version>7.116.0</version>
+        <version>10.73.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mvnpm.at.sentry</groupId>
+        <artifactId>replay-canvas</artifactId>
+        <version>10.73.0</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.sentry</groupId>
         <artifactId>types</artifactId>
-        <version>10.56.0</version>
+        <version>10.73.0</version>
       </dependency>
       <dependency>
         <groupId>org.mvnpm.at.sentry</groupId>

--- a/web-deps/pom.xml
+++ b/web-deps/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.mvnpm.at.sentry</groupId>
             <artifactId>browser</artifactId>
-            <version>10.56.0</version>
+            <version>10.73.0</version>
         </dependency>
         <dependency>
             <groupId>org.mvnpm.at.segment</groupId>


### PR DESCRIPTION
Between Sentry 10.57.0 and 10.73.0, the `@sentry-internal/*` packages were renamed to `@sentry/*`:

- `@sentry-internal/feedback` → `@sentry/feedback`
- `@sentry-internal/replay-canvas` → `@sentry/replay-canvas`
- `@sentry-internal/browser-utils` → `@sentry/browser-utils`
- `@sentry-internal/replay` → `@sentry/replay`

This caused the Mintmaker PR #1826 to fail: it bumped `@sentry/browser/core/types` to 10.73.0 but kept the old `@sentry-internal` package names in the lock file at 10.57.0, which are incompatible with `@sentry/core` 10.73.0.

This PR:
- Bumps `@sentry/browser` to 10.73.0 in `web-deps/pom.xml`
- Updates the lock file: removes `@sentry-internal/feedback` and `@sentry-internal/replay-canvas`, adds the renamed `@sentry/*` equivalents and new transitive dep `@sentry/conventions`
- Verified locally with a full `base` module build (esbuild bundling passes)

Closes #1826 (supersedes it).